### PR TITLE
Use node-qunit testrunner instead of CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "keywords": ["regex", "regexp"],
     "main": "xregexp-all.js",
     "scripts": {
-        "test": "qunit -c xregexp:./xregexp-all.js -t ./tests/tests.js"
+        "test": "node tests/node-qunit.js"
     },
     "devDependencies": {
         "qunit": ">= 0.2.x"

--- a/tests/node-qunit.js
+++ b/tests/node-qunit.js
@@ -1,0 +1,11 @@
+// Use node-qunit to run the tests.
+
+var qunit = require("qunit");
+
+qunit.run({
+    code: {
+        namespace: "xregexp",
+        path: __dirname + "/../xregexp-all.js"
+    },
+    tests: __dirname + "/tests.js"
+});


### PR DESCRIPTION
This makes it possible to use locally or globally installed qunit, as `npm test` does not depend on the command line `qunit`.
