### PR TITLE
Patch for using a group name multiple times

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1,7 +1,7 @@
 /*!
  * XRegExp 3.0.0-pre
  * <http://xregexp.com/>
- * Steven Levithan © 2007-2012 MIT License
+ * Steven Levithan ï¿½ 2007-2012 MIT License
  */
 
 /**
@@ -1253,7 +1253,9 @@ var XRegExp = (function(undefined) {
                 for (i = 1; i < match.length; ++i) {
                     name = this[REGEX_DATA].captureNames[i - 1];
                     if (name) {
-                        match[name] = match[i];
+                        if (match[i] != undef || match[name] == undef) {
+                            match[name] = match[i];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I've added a small feature to the code making named groups slightly more powerful.

Previously, if you used the same group name multiple times, it would have just used the value stored in the last group of that name (even if it failed to find that group).

Now it will only use the last successfully found group.
