### PR TITLE
Allow for usage in meteor 0.6.5 and higer

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -10,7 +10,7 @@
  * to make your client-side grepping simpler and more powerful, while freeing you from worrying
  * about pesky cross-browser inconsistencies and the dubious `lastIndex` property.
  */
-var XRegExp = (function(undefined) {
+window.XRegExp = (function(undefined) {
     'use strict';
 
 /* ==============================


### PR DESCRIPTION
For meteor 0.6.5 and higher, the used library files must explicitly define a global (e.g. there must be no var prefix)
