### PR TITLE
Fixes #65: String.replace polyfill throws SyntaxError for valid replacement values

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1430,7 +1430,9 @@ var XRegExp = (function(undefined) {
                         }
                         return args[$2] || '';
                     }
-                    throw new SyntaxError('Invalid token ' + $0);
+                    // From ECMA-262 § 15.5.4.11:
+                    // "A $ in newstring that does not match any of the forms [above] is left as is."
+                    return $0;
                 });
             });
         }


### PR DESCRIPTION
Fix was a one-liner (returning `$0` instead of throwing a `SyntaxError`).

All unit tests passed.

I wasn't sure how to properly re-build `xregexp-all.js` and friends, so I'll leave that to your capable hands.
