### PR TITLE
bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+    "name": "xregexp",
+    "main": "xregexp-all.js",
+    "authors": [
+        "Steven Levithan <steves_list@hotmail.com>"
+    ],
+    "description": "Extended regular expressions",
+    "dependencies": {},
+    "devDependencies": {},
+    "moduleType": [
+        "amd",
+        "globals",
+        "node"
+    ],
+    "homepage": "http://xregexp.com/",
+    "license": "MIT",
+    "keywords": [
+        "regex",
+        "regexp"
+    ],
+    "ignore": [
+        "**/.*",
+        "package.json",
+        "README.md",
+        "src",
+        "tests",
+        "tools"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/slevithan/xregexp.git"
+    }
+}
+


### PR DESCRIPTION
Add bower.json to support bower.io

Most fields were copied from package.json but wasn't sure what to add for ```dependencies``` and ```devDependencies```.  Explanation for what to put in those fields is at http://bower.io/docs/creating-packages/

You will also need to register the XRegExp package with bower once bower.json has been added, using the instructions provided at the above link.

#63 #78