### PR TITLE
Implement .names

### DIFF
--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -40,7 +40,7 @@
  */
     function asXRegExp(value) {
         return XRegExp.isRegExp(value) ?
-            (value[REGEX_DATA] && value[REGEX_DATA].captureNames ?
+            (value[REGEX_DATA] && value[REGEX_DATA]._captures ?
                 // Don't recompile, to preserve capture names
                 value :
                 // Recompile as XRegExp
@@ -106,7 +106,7 @@
                     // Deanchoring allows embedding independently useful anchored regexes. If you
                     // really need to keep your anchors, double them (i.e., `^^...$$`)
                     pattern: deanchor(sub.source),
-                    names: sub[REGEX_DATA].captureNames || []
+                    names: sub[REGEX_DATA]._captures || []
                 };
             }
         }
@@ -114,7 +114,7 @@
         // Passing to XRegExp dies on octals and ensures the outer pattern is independently valid;
         // helps keep this simple. Named captures will be put back
         pattern = asXRegExp(pattern);
-        outerCapNames = pattern[REGEX_DATA].captureNames || [];
+        outerCapNames = pattern[REGEX_DATA]._captures || [];
         pattern = pattern.source.replace(parts, function($0, $1, $2, $3, $4) {
             var subName = $1 || $2, capName, intro;
             // Named subpattern

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -110,9 +110,21 @@ var XRegExp = (function(undefined) {
  */
     function augment(regex, captureNames, xSource, xFlags, isInternalOnly) {
         var p;
+        var names = [];
+
+        // Set .names to a list of the named capture groups without any null
+        // values for unnamed capture groups as is the behaviour of captureNames
+        if (captureNames) {
+            for (var i = 0; i < captureNames.length; i++) {
+                if (captureNames[i] !== null) {
+                    names.push(captureNames[i]);
+                }
+            }
+        }
 
         regex[REGEX_DATA] = {
-            captureNames: captureNames
+            captureNames: captureNames,
+            names: names
         };
 
         if (isInternalOnly) {

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -534,6 +534,16 @@ describe('XRegExp.forEach()', function() {
         expect(result).toEqual([regex[REGEX_DATA].source, regex[REGEX_DATA].flags]);
     });
 
+    it('should include named capture groups on source regexes in callback functions', function() {
+        var regex = XRegExp('(?<a>\\w+)', 'x');
+        var result = [];
+        XRegExp.forEach('abc 123 def', regex, function(m, i, s, r) {
+            result.push(r[REGEX_DATA].names);
+        });
+
+        expect(result).toEqual([regex[REGEX_DATA].names, regex[REGEX_DATA].names, regex[REGEX_DATA].names]);
+    });
+
     it('should not let iteration be affected by source string manipulation in the callback function', function() {
         var str1 = 'abc 123 def';
         var str2 = 'abc 123 def';

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -155,7 +155,7 @@ describe('XRegExp()', function() {
         expect(function() {XRegExp('', '?');}).toThrowError(SyntaxError);
     });
 
-    it('should store named capture data on regex instances', function() {
+    it('should store capture data on regex instances', function() {
         // The `captureNames` property is undocumented, so this is technically just testing
         // implementation details. However, any changes to this need to be very intentional
         var tests = [
@@ -169,6 +169,21 @@ describe('XRegExp()', function() {
         ];
         tests.forEach(function(test) {
             expect(test.regex[REGEX_DATA].captureNames).toEqual(test.captureNames);
+        });
+    });
+
+    it('should store named capture data on regex instances', function() {
+        var tests = [
+            {regex: XRegExp(''), names: []},
+            {regex: XRegExp('()'), names: []},
+            {regex: XRegExp('(?<a>)'), names: ['a']},
+            {regex: XRegExp('(?<a>)()(?<b>)'), names: ['a', 'b']},
+            {regex: XRegExp('(?<a>((?<b>)))'), names: ['a', 'b']},
+            {regex: XRegExp('(?n)()'), names: []},
+            {regex: XRegExp('(?n)(?<a>)()(?<b>)'), names: ['a', 'b']}
+        ];
+        tests.forEach(function(test) {
+            expect(test.regex[REGEX_DATA].names).toEqual(test.names);
         });
     });
 
@@ -218,8 +233,12 @@ describe('XRegExp()', function() {
         expect(function() {XRegExp(/\00/);}).not.toThrow();
     });
 
-    it('should preserve named capture data when copying a regex', function() {
+    it('should preserve capture data when copying a regex', function() {
         expect(XRegExp(XRegExp('(?<name>a)'))[REGEX_DATA].captureNames).toContain('name');
+    });
+
+    it('should preserve named capture data when copying a regex', function() {
+        expect(XRegExp(XRegExp('(?<name>a)'))[REGEX_DATA].names).toContain('name');
     });
 
     it('should preserve precompilation source and flags when copying a regex', function() {
@@ -270,7 +289,7 @@ describe('XRegExp()', function() {
             it('should set properties for native flags', function() {
                 expect(XRegExp('(?i)').ignoreCase).toBe(true);
                 expect(XRegExp('(?m)').multiline).toBe(true);
-    
+
                 var regexIM = XRegExp('(?im)');
                 expect(regexIM.ignoreCase).toBe(true);
                 expect(regexIM.multiline).toBe(true);

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -156,19 +156,19 @@ describe('XRegExp()', function() {
     });
 
     it('should store capture data on regex instances', function() {
-        // The `captureNames` property is undocumented, so this is technically just testing
+        // The `_captures` property is undocumented, so this is technically just testing
         // implementation details. However, any changes to this need to be very intentional
         var tests = [
-            {regex: XRegExp(''), captureNames: null},
-            {regex: XRegExp('()'), captureNames: null},
-            {regex: XRegExp('(?<a>)'), captureNames: ['a']},
-            {regex: XRegExp('(?<a>)()(?<b>)'), captureNames: ['a', null, 'b']},
-            {regex: XRegExp('(?<a>((?<b>)))'), captureNames: ['a', null, 'b']},
-            {regex: XRegExp('(?n)()'), captureNames: null},
-            {regex: XRegExp('(?n)(?<a>)()(?<b>)'), captureNames: ['a', 'b']}
+            {regex: XRegExp(''), _captures: null},
+            {regex: XRegExp('()'), _captures: null},
+            {regex: XRegExp('(?<a>)'), _captures: ['a']},
+            {regex: XRegExp('(?<a>)()(?<b>)'), _captures: ['a', null, 'b']},
+            {regex: XRegExp('(?<a>((?<b>)))'), _captures: ['a', null, 'b']},
+            {regex: XRegExp('(?n)()'), _captures: null},
+            {regex: XRegExp('(?n)(?<a>)()(?<b>)'), _captures: ['a', 'b']}
         ];
         tests.forEach(function(test) {
-            expect(test.regex[REGEX_DATA].captureNames).toEqual(test.captureNames);
+            expect(test.regex[REGEX_DATA]._captures).toEqual(test._captures);
         });
     });
 
@@ -234,7 +234,7 @@ describe('XRegExp()', function() {
     });
 
     it('should preserve capture data when copying a regex', function() {
-        expect(XRegExp(XRegExp('(?<name>a)'))[REGEX_DATA].captureNames).toContain('name');
+        expect(XRegExp(XRegExp('(?<name>a)'))[REGEX_DATA]._captures).toContain('name');
     });
 
     it('should preserve named capture data when copying a regex', function() {


### PR DESCRIPTION
Per https://github.com/slevithan/xregexp/issues/45#issuecomment-142207025

> - Add `<regexp>.xregexp.names` to all XRegExps. `names` is an array of 0+ strings holding the names of named capturing groups used by the regex, unlike `captureNames`' interspersed `null`s for unnamed capturing groups and `null` value if there are no named groups.
> - Rename `captureNames` as `_captures`. This is technically a non-breaking change because `<regexp>.xregexp.captureNames` is undocumented.
> - Ensure a copy of the `names` array is added to regexes copied via `XRegExp(regexp)` and `XRegExp.globalize(regexp)`.
> - Ensure that `<regexp>.xregexp.names` is available on the regex passed as the 4th argument to `XRegExp.forEach` callbacks.
> - Add tests for all of the above.
