### PR TITLE
fix AMD detection

### DIFF
--- a/tools/intro.js
+++ b/tools/intro.js
@@ -8,7 +8,7 @@
 // Don't use strict mode for this function, so it can assign to global
 ;(function(root, definition) {
     // RequireJS
-    if (typeof define === 'function') {
+    if (typeof define === 'function' && define.amd) {
         define(definition);
     // CommonJS
     } else if (typeof exports === 'object') {

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -8,7 +8,7 @@
 // Don't use strict mode for this function, so it can assign to global
 ;(function(root, definition) {
     // RequireJS
-    if (typeof define === 'function') {
+    if (typeof define === 'function' && define.amd) {
         define(definition);
     // CommonJS
     } else if (typeof exports === 'object') {


### PR DESCRIPTION
The Firefox Addon SDK defines a global `define` function, which XRegExp's UMD stanza mistakes for AMD. Adding a check for `define.amd` fixes this and is the standard way to detect AMD:

https://github.com/umdjs/umd/blob/3e14a7dfb0af2bd3a8bfe9b7b384d698e3ef75e4/amdWeb.js#L19
