### PR TITLE
GH-112 Allow (?:)*/+/?/{1} without causing a syntax error

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -612,7 +612,7 @@ var XRegExp = (function(undefined) {
 
             patternCache[pattern][flags] = {
                 // Cleanup token cruft: repeated `(?:)(?:)` and leading/trailing `(?:)`
-                pattern: nativ.replace.call(output, /\(\?:\)(?=\(\?:\))|^\(\?:\)|\(\?:\)$/g, ''),
+                pattern: nativ.replace.call(output, /\(\?:\)(?:[*+?]|\{\d+(?:,\d*)?})?\??(?=\(\?:\))|^\(\?:\)(?:[*+?]|\{\d+(?:,\d*)?})?\??|\(\?:\)(?:[*+?]|\{\d+(?:,\d*)?})?\??$/g, ''),
                 // Strip all but native flags
                 flags: nativ.replace.call(appliedFlags, /[^gimuy]+/g, ''),
                 // `context.captureNames` has an item for each capturing group, even if unnamed

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -155,6 +155,14 @@ describe('XRegExp()', function() {
         expect(function() {XRegExp('', '?');}).toThrowError(SyntaxError);
     });
 
+    it('should allow (?:) followed by a quantifier as a pattern', function() {
+        var quantifiers = ['*', '+', '?', '{1}', '{1,}', '{1,2}', '??', '*?', '+?'];
+
+        for (var i = 0; i < quantifiers.length; i++) {
+            expect(function() {XRegExp('(?:)' + quantifiers[i], 'g');}).not.toThrow();
+        }
+    });
+
     it('should store named capture data on regex instances', function() {
         // The `captureNames` property is undocumented, so this is technically just testing
         // implementation details. However, any changes to this need to be very intentional
@@ -270,7 +278,7 @@ describe('XRegExp()', function() {
             it('should set properties for native flags', function() {
                 expect(XRegExp('(?i)').ignoreCase).toBe(true);
                 expect(XRegExp('(?m)').multiline).toBe(true);
-    
+
                 var regexIM = XRegExp('(?im)');
                 expect(regexIM.ignoreCase).toBe(true);
                 expect(regexIM.multiline).toBe(true);


### PR DESCRIPTION
This fixes https://github.com/slevithan/xregexp/issues/112

The new cleanup regex also cleans up `*`, `+`, `?` or `{\d}` after an empty capture group. 
You can see a demo here: http://rubular.com/r/AFFiDroJEg 