### PR TITLE
allow \x as alternative to \u for unicode code points 

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1701,7 +1701,7 @@ var XRegExp = (function(undefined) {
  * if you use the same in a character class.
  */
     add(
-        /\\u{([\dA-Fa-f]+)}/,
+        /(?:(?:\\u)|(?:\\x)){([\dA-Fa-f]+)}/,
         function(match, scope, flags) {
             var code = dec(match[1]);
             if (code > 0x10FFFF) {
@@ -1713,7 +1713,7 @@ var XRegExp = (function(undefined) {
                 return '\\u' + pad4(hex(code));
             }
             // If `code` is between 0xFFFF and 0x10FFFF, require and defer to native handling
-            if (hasNativeU && flags.indexOf('u') > -1) {
+            if (hasNativeU && (flags.indexOf('u') > -1 || flags.indexOf('x') > -1)) {
                 return match[0];
             }
             throw new SyntaxError('Cannot use Unicode code point above \\u{FFFF} without flag u');

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -643,6 +643,13 @@ describe('XRegExp()', function() {
                 expect(XRegExp('a{\\u{31}}').test('a{1}')).toBe(true);
             });
 
+            it("it allows 'x' flag as alternative to 'u'", function() {
+                expect(XRegExp('\\x{1}').test('\u0001')).toBe(true);
+                expect(XRegExp('\\x{10}').test('\u0010')).toBe(true);
+                expect(XRegExp('\\x{100}').test('\u0100')).toBe(true);
+                expect(XRegExp('\\x{1000}').test('\u1000')).toBe(true);
+            });
+
         });
 
         // Unicode property syntax is covered by the specs for Unicode Base


### PR DESCRIPTION
As outlined here:

http://www.regular-expressions.info/unicode.html

`\x` is used as an alternative to `\u' in some regex engines (I'm specifically thinking of [oniguruma](https://github.com/rubinius/oniguruma)) which I'm working on writing some shims for.

It would be nice if `\x{xxxx}` was accepted as an alternative to `\u{xxxx}` I can work around this with an add on for the time being :+1: 
