### PR TITLE
More web-compatible way to feature-test for sticky RegExp support

### DIFF
--- a/tests/perf/versions/xregexp-all-v1.5.1.js
+++ b/tests/perf/versions/xregexp-all-v1.5.1.js
@@ -119,7 +119,7 @@ if (XRegExp) {
             nativ.test.call(x, "");
             return !x.lastIndex;
         }(),
-        hasNativeY = RegExp.prototype.sticky !== undefined,
+        hasNativeY = RegExp.prototype.hasOwnProperty('sticky'),
         nativeTokens = {};
 
     // `nativeTokens` match native multicharacter metasequences only (including deprecated octals,

--- a/tests/perf/versions/xregexp-all-v2.0.0.js
+++ b/tests/perf/versions/xregexp-all-v2.0.0.js
@@ -79,7 +79,7 @@ XRegExp = XRegExp || (function (undef) {
         compliantExecNpcg = nativ.exec.call(/()??/, "")[1] === undef,
 
 // Check for flag y support (Firefox 3+)
-        hasNativeY = RegExp.prototype.sticky !== undef,
+        hasNativeY = RegExp.prototype.hasOwnProperty('sticky'),
 
 // Used to kill infinite recursion during XRegExp construction
         isInsideConstructor = false,


### PR DESCRIPTION
This is to work around https://bugs.chromium.org/p/v8/issues/detail?id=4617