### PR TITLE
added API `XRegExp.isUnicodeSlug(name)` which checks whether a given `name` is a recognized Unicode Slug

### DIFF
--- a/src/addons/unicode-base.js
+++ b/src/addons/unicode-base.js
@@ -225,19 +225,41 @@ module.exports = function(XRegExp) {
     };
 
     /**
-     * Test if the given name is a legal Unicode Slug for use in XRegExp `\p` or `\P` regex constructs.
+     * @ignore
+     *
+     * Return a reference to the internal Unicode definition structure for the given Unicode Property
+     * if the given name is a legal Unicode Property for use in XRegExp `\p` or `\P` regex constructs.
      *
      * @memberOf XRegExp
-     * @param {String} name Name by which the Unicode slug may be recognized (case-insensitive),
+     * @param {String} name Name by which the Unicode Property may be recognized (case-insensitive),
      *   e.g. `'N'` or `'Number'`.
-     *   
-     *   The given name is matched against all registered Unicode names and aliases.
      *
-     * @return {Object} Truthy when the name matches a Unicode slug (the internal slug definition
-     *   object is returned); `false` when the name does not match *any* Unicode name or alias. 
+     *   The given name is matched against all registered Unicode Properties and Property Aliases.
+     *
+     * @return {Object} Reference to definition structure when the name matches a Unicode Property;
+     * `false` when the name does not match *any* Unicode Property or Property Alias.
+     *
+     * @note
+     * For more info on Unicode Properties, see also http://unicode.org/reports/tr18/#Categories.
+     *
+     * @note
+     * This method is *not* part of the officially documented and published API and is meant 'for
+     * advanced use only' where userland code wishes to re-use the (large) internal Unicode
+     * structures set up by XRegExp as a single point of Unicode 'knowledge' in the application.
+     *
+     * See some example usage of this functionality, used as a boolean check if the given name
+     * is legal and to obtain internal structural data:
+     * - `function prepareMacros(...)` in https://github.com/GerHobbelt/jison-lex/blob/master/regexp-lexer.js#L885
+     * - `function generateRegexesInitTableCode(...)` in https://github.com/GerHobbelt/jison-lex/blob/master/regexp-lexer.js#L1999
+     *
+     * Note that the second function in the example (`function generateRegexesInitTableCode(...)`)
+     * uses a approach without using this API to obtain a Unicode range spanning regex for use in environments
+     * which do not support XRegExp by simply expanding the XRegExp instance to a String through
+     * the `map()` mapping action and subsequent `join()`.
      */
-    XRegExp.isUnicodeSlug = function(name) {
-        return unicode[normalize(name)] || false;
+    XRegExp._getUnicodeProperty = function(name) {
+        var slug = normalize(name);
+        return unicode[slug] || false;
     };
 
 };

--- a/src/addons/unicode-base.js
+++ b/src/addons/unicode-base.js
@@ -224,4 +224,20 @@ module.exports = function(XRegExp) {
         XRegExp.cache.flush('patterns');
     };
 
+    /**
+     * Test if the given name is a legal Unicode Slug for use in XRegExp `\p` or `\P` regex constructs.
+     *
+     * @memberOf XRegExp
+     * @param {String} name Name by which the Unicode slug may be recognized (case-insensitive),
+     *   e.g. `'N'` or `'Number'`.
+     *   
+     *   The given name is matched against all registered Unicode names and aliases.
+     *
+     * @return {Object} Truthy when the name matches a Unicode slug (the internal slug definition
+     *   object is returned); `false` when the name does not match *any* Unicode name or alias. 
+     */
+    XRegExp.isUnicodeSlug = function(name) {
+        return unicode[normalize(name)] || false;
+    };
+
 };


### PR DESCRIPTION
added API `XRegExp.isUnicodeSlug(name)` which checks whether a given `name` is a recognized Unicode Slug, e.g. `Number` (but not `Numeric` as `\p{Numeric}` is an _invalid_ Unicode `\p` regex slug.  This API is used by the GerHobbelt/jison app to help add Unicode support to the grammars being compiled. The way the API internals (**and documentation**, see the comment block in the patch) is written, i.e. that rather than a plain `true` boolean value, a 'truthy' Unicode slug definition is produced, is also used by the GerHobbelt/jison app: that code generator uses this artifact to greatly simplify lexer regex expansion and rewriting.
