### PR TITLE
Optimize sticky matching

### DIFF
--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -603,6 +603,44 @@ module.exports = function(XRegExp) {
         XRegExp.cache.flush('patterns');
     };
 
+    /**
+     * @ignore
+     *
+     * Return a reference to the internal Unicode definition structure for the given Unicode Property
+     * if the given name is a legal Unicode Property for use in XRegExp `\p` or `\P` regex constructs.
+     *
+     * @memberOf XRegExp
+     * @param {String} name Name by which the Unicode Property may be recognized (case-insensitive),
+     *   e.g. `'N'` or `'Number'`.
+     *
+     *   The given name is matched against all registered Unicode Properties and Property Aliases.
+     *
+     * @return {Object} Reference to definition structure when the name matches a Unicode Property;
+     * `false` when the name does not match *any* Unicode Property or Property Alias.
+     *
+     * @note
+     * For more info on Unicode Properties, see also http://unicode.org/reports/tr18/#Categories.
+     *
+     * @note
+     * This method is *not* part of the officially documented and published API and is meant 'for
+     * advanced use only' where userland code wishes to re-use the (large) internal Unicode
+     * structures set up by XRegExp as a single point of Unicode 'knowledge' in the application.
+     *
+     * See some example usage of this functionality, used as a boolean check if the given name
+     * is legal and to obtain internal structural data:
+     * - `function prepareMacros(...)` in https://github.com/GerHobbelt/jison-lex/blob/master/regexp-lexer.js#L885
+     * - `function generateRegexesInitTableCode(...)` in https://github.com/GerHobbelt/jison-lex/blob/master/regexp-lexer.js#L1999
+     *
+     * Note that the second function in the example (`function generateRegexesInitTableCode(...)`)
+     * uses a approach without using this API to obtain a Unicode range spanning regex for use in environments
+     * which do not support XRegExp by simply expanding the XRegExp instance to a String through
+     * the `map()` mapping action and subsequent `join()`.
+     */
+    XRegExp._getUnicodeProperty = function(name) {
+        var slug = normalize(name);
+        return unicode[slug] || false;
+    };
+
 };
 
 },{}],4:[function(require,module,exports){
@@ -2667,7 +2705,7 @@ var hasFlagsProp = /x/.flags !== undefined;
 var toString = {}.toString;
 
 function hasNativeFlag(flag) {
-    // Can't check based on the presense of properties/getters since browsers might support such
+    // Can't check based on the presence of properties/getters since browsers might support such
     // properties even when they don't support the corresponding flag in regex construction (tested
     // in Chrome 48, where `'unicode' in /x/` is true but trying to construct a regex with flag `u`
     // throws an error)

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2848,7 +2848,7 @@ function copyRegex(regex, options) {
     // unnecessary for regexes constructed by `XRegExp` because the regex has already undergone the
     // translation to native regex syntax
     regex = augment(
-        new RegExp(regex.source, flags),
+        new RegExp(options.source || regex.source, flags),
         hasNamedCapture(regex) ? xData.captureNames.slice(0) : null,
         xregexpSource,
         xregexpFlags,
@@ -3436,13 +3436,23 @@ XRegExp.escape = function(str) {
 XRegExp.exec = function(str, regex, pos, sticky) {
     var cacheKey = 'g',
         addY = false,
+        sourceY,
         match,
         r2;
 
     addY = hasNativeY && !!(sticky || (regex.sticky && sticky !== false));
     if (addY) {
         cacheKey += 'y';
+    } else if (sticky) {
+        // Simulate sticky matching by appending an empty capture to the original regexp.
+        // The resulting regexp will succeed no matter what at the current index (set with
+        // `lastIndex`), it will not search the rest of the subject string. We'll know that
+        // the original regexp has failed if that last capture is not `undefined`.
+        sourceY = regex.source + '|()';
+        cacheKey += 'FakeY';
     }
+
+
 
     regex[REGEX_DATA] = regex[REGEX_DATA] || {};
 
@@ -3451,6 +3461,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
         regex[REGEX_DATA][cacheKey] = copyRegex(regex, {
             addG: true,
             addY: addY,
+            source: sourceY,
             removeY: sticky === false,
             isInternalOnly: true
         })
@@ -3461,7 +3472,9 @@ XRegExp.exec = function(str, regex, pos, sticky) {
     // Fixed `exec` required for `lastIndex` fix, named backreferences, etc.
     match = fixed.exec.call(r2, str);
 
-    if (sticky && match && match.index !== pos) {
+    // Get rid of the capture added by the pseudo-sticky matcher if needed. An empty string
+    // means the original regexp failed (see above)
+    if (sourceY && match && match.pop() === '') {
         match = null;
     }
 


### PR DESCRIPTION
[Baseline (build of the current master)](https://github.com/pygy/xregexp/blob/c28faa33c5be869e68e626da27021d35d1a02793/tests/perf/index.html)

[Proposed patch](https://cdn.rawgit.com/pygy/xregexp/8f8acf728ec840e35868b5a62e54878ac99a7465/tests/perf/index.html)

[Test suite post-build](https://cdn.rawgit.com/pygy/xregexp/8f8acf728ec840e35868b5a62e54878ac99a7465/tests/index.html)

I've only tested this in an old Chromium build so far that doesn't have `y`. The sticky benchmark performance is one order of magnitude better.

I've also had 2x improvements in the non-cache/non-flush XRegExp constructor tests, but they are not reliably reproducible.

I'll try it in SauceLabs later today for older IE versions.

Edit: one order of magnitude, not "orders"... Still, better ;-). Sticky matching goes from `O(N * complexity(regexp))` to `O(1 * complexity(regexp))` where N is the string length.