### PR TITLE
Don't allocate the sticky regex source when the resulting regexp is already cached

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -815,7 +815,7 @@ XRegExp.escape = function(str) {
 XRegExp.exec = function(str, regex, pos, sticky) {
     var cacheKey = 'g',
         addY = false,
-        sourceY,
+        fakeY = false,
         match,
         r2;
 
@@ -828,7 +828,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
         // and will not search the rest of the subject string. We'll know that the original regex
         // has failed if that last capture is `''` rather than `undefined` (i.e., if that last
         // capture participated in the match).
-        sourceY = regex.source + '|()';
+        fakeY = true;
         cacheKey += 'FakeY';
     }
 
@@ -839,7 +839,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
         regex[REGEX_DATA][cacheKey] = copyRegex(regex, {
             addG: true,
             addY: addY,
-            source: sourceY,
+            source: fakeY ? regex.source + '|()' : undefined,
             removeY: sticky === false,
             isInternalOnly: true
         })
@@ -853,7 +853,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
 
     // Get rid of the capture added by the pseudo-sticky matcher if needed. An empty string means
     // the original regexp failed (see above).
-    if (sourceY && match && match.pop() === '') {
+    if (fakeY && match && match.pop() === '') {
         match = null;
     }
 

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -3461,7 +3461,7 @@ XRegExp.escape = function(str) {
 XRegExp.exec = function(str, regex, pos, sticky) {
     var cacheKey = 'g',
         addY = false,
-        sourceY,
+        fakeY = false,
         match,
         r2;
 
@@ -3474,7 +3474,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
         // and will not search the rest of the subject string. We'll know that the original regex
         // has failed if that last capture is `''` rather than `undefined` (i.e., if that last
         // capture participated in the match).
-        sourceY = regex.source + '|()';
+        fakeY = true;
         cacheKey += 'FakeY';
     }
 
@@ -3485,7 +3485,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
         regex[REGEX_DATA][cacheKey] = copyRegex(regex, {
             addG: true,
             addY: addY,
-            source: sourceY,
+            source: fakeY ? regex.source + '|()' : undefined,
             removeY: sticky === false,
             isInternalOnly: true
         })
@@ -3499,7 +3499,7 @@ XRegExp.exec = function(str, regex, pos, sticky) {
 
     // Get rid of the capture added by the pseudo-sticky matcher if needed. An empty string means
     // the original regexp failed (see above).
-    if (sourceY && match && match.pop() === '') {
+    if (fakeY && match && match.pop() === '') {
         match = null;
     }
 


### PR DESCRIPTION
As discussed previously in #152 and #153