### PR TITLE
Add test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "src"
   ],
   "scripts": {
-    "build": "browserify src/index.js --standalone XRegExp > xregexp-all.js"
+    "build": "browserify src/index.js --standalone XRegExp > xregexp-all.js",
+    "pretest": "npm run build",
+    "test": "opener tests/index.html"
   },
   "devDependencies": {
-    "browserify": "^12.0.1"
+    "browserify": "^12.0.1",
+    "opener": "^1.4.2"
   }
 }


### PR DESCRIPTION
This makes it easier for new developers to run the tests, by typing `npm
test`. This will build `xregexp-all.js`, then open `tests/index.html` in a
browser, using [opener].

[opener]: https://www.npmjs.com/package/opener