### PR TITLE
Add max_line_length to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 100


### PR DESCRIPTION
It looks like comments have manually been wrapped to 100 characters, so
use that as the [max_line_length] in the .editorconfig file.

[max_line_length]: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length