### PR TITLE
Make tests run in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "scripts": {
     "build": "browserify src/index.js --standalone XRegExp > xregexp-all.js",
     "pretest": "npm run build",
-    "test": "opener tests/index.html"
+    "test": "jasmine JASMINE_CONFIG_PATH=tests/jasmine.json"
   },
   "devDependencies": {
     "browserify": "^12.0.1",
-    "opener": "^1.4.2"
+    "jasmine": "^2.5.3"
   }
 }

--- a/tests/helpers/h-unicode.js
+++ b/tests/helpers/h-unicode.js
@@ -1,8 +1,11 @@
+if (typeof global === 'undefined') {
+    global = window;
+}
 /*
  * Runs a series of `expect` assertions, given a Unicode token name and arrays of code points that
  * should or should not be matched.
  */
-function testUnicodeToken(name, options) {
+global.testUnicodeToken = function (name, options) {
     var pattern = '^\\p{' + name + '}$';
     var negated = '^\\P{' + name + '}$';
     var astralRegex = XRegExp(pattern, 'A');

--- a/tests/helpers/h.js
+++ b/tests/helpers/h.js
@@ -1,22 +1,28 @@
+if (typeof global === 'undefined') {
+    global = window;
+} else {
+    global.XRegExp = require('../../xregexp-all');
+}
+
 // Ensure that all opt-in features are disabled when each spec starts
 beforeEach(function() {
     XRegExp.uninstall('natives astral');
 });
 
 // Repeat a string the specified number of times
-function repeat(str, num) {
+global.repeat = function (str, num) {
     return Array(num + 1).join(str);
 }
 
 // Property name used for extended regex instance data
-var REGEX_DATA = 'xregexp';
+global.REGEX_DATA = 'xregexp';
 
 // Check for ES6 `u` flag support
-var hasNativeU = XRegExp._hasNativeFlag('u');
+global.hasNativeU = XRegExp._hasNativeFlag('u');
 // Check for ES6 `y` flag support
-var hasNativeY = XRegExp._hasNativeFlag('y');
+global.hasNativeY = XRegExp._hasNativeFlag('y');
 // Check for strict mode support
-var hasStrictMode = (function() {'use strict'; return !this;}());
+global.hasStrictMode = (function() {'use strict'; return !this;}());
 
 // Add the complete ES5 Array.prototype.forEach shim from <https://github.com/kriskowal/es5-shim>.
 // Commented out the `if (i in self)` sparse array check because it causes this to skip keys with

--- a/tests/jasmine.json
+++ b/tests/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "tests",
+  "spec_files": [
+    "spec/**/*.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/slevithan/xregexp/pull/155#issuecomment-279608958
that lets the tests run in Node, without opening a browser. It's set up
so that opening tests/index.html still works, for anyone who prefers
that workflow.

See the jasmine docs for more info on using it with Node: https://jasmine.github.io/2.5/node.html