### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 100
+
+[*.yml]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - node

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[XRegExp](http://xregexp.com/) 3.1.1
+[XRegExp](http://xregexp.com/) 3.1.1 [![Build Status](https://travis-ci.org/slevithan/xregexp.svg?branch=master)](https://travis-ci.org/slevithan/xregexp)
 ====================================
 
 XRegExp provides augmented (and extensible) JavaScript regular expressions. You get new modern syntax and flags beyond what browsers support natively. XRegExp is also a regex utility belt with tools to make your client-side grepping and parsing easier, while freeing you from worrying about pesky aspects of JavaScript regexes like cross-browser inconsistencies or manually manipulating `lastIndex`.


### PR DESCRIPTION
Following up on https://github.com/slevithan/xregexp/pull/155#issuecomment-279614509,
here are some changes that set up [Travis CI] for this repo. To enable
it, all you'll need to do is sign in to Travis using Github, then go to
your [profile] and hit the switch beside `slevithan/xregexp`. Here's an
example of what a build looks like: https://travis-ci.org/josephfrazier/xregexp/builds/201410109

[Travis CI]: https://travis-ci.org/
[profile]: https://travis-ci.org/profile/slevithan