### PR TITLE
Pass XRegExp.build flags through asXRegExp to XRegExp constructor

### DIFF
--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -85,6 +85,12 @@ module.exports = function(XRegExp) {
      */
     XRegExp.build = function(pattern, subs, flags) {
         var inlineFlags = /^\(\?([\w$]+)\)/.exec(pattern),
+            // These flags will be passed to the asXRegExp calls for `pattern` and for every
+            // subpattern in `subs`. This is to work around the following browser bugs:
+            //
+            // * Firefox converts '\n' to a regex that contains the literal characters \ and n
+            //   You can verify this by running `console.log(RegExp('\n').source)`
+            //   See here for more details: https://github.com/slevithan/xregexp/pull/163
             asXRegExpFlags = (flags || '').indexOf('x') > -1 ? 'x' : '',
             data = {},
             numCaps = 0, // 'Caps' is short for captures

--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -38,22 +38,24 @@ module.exports = function(XRegExp) {
     }
 
     /**
-     * Converts the provided value to an XRegExp. Native RegExp flags are not preserved.
+     * Converts the provided value to an XRegExp. Native RegExp flags are not preserved. Flags can
+     * be provided as a separate argument.
      *
      * @private
      * @param {String|RegExp} value Value to convert.
+     * @param {String} [flags] Any combination of XRegExp flags.
      * @returns {RegExp} XRegExp object with XRegExp syntax applied.
      */
-    function asXRegExp(value) {
+    function asXRegExp(value, flags) {
         return XRegExp.isRegExp(value) ?
             (value[REGEX_DATA] && value[REGEX_DATA].captureNames ?
                 // Don't recompile, to preserve capture names
                 value :
                 // Recompile as XRegExp
-                XRegExp(value.source)
+                XRegExp(value.source, flags)
             ) :
             // Compile string as XRegExp
-            XRegExp(value);
+            XRegExp(value, flags);
     }
 
     /**
@@ -119,7 +121,7 @@ module.exports = function(XRegExp) {
 
         // Passing to XRegExp dies on octals and ensures the outer pattern is independently valid;
         // helps keep this simple. Named captures will be put back
-        pattern = asXRegExp(pattern);
+        pattern = asXRegExp(pattern, flags);
         outerCapNames = pattern[REGEX_DATA].captureNames || [];
         pattern = pattern.source.replace(parts, function($0, $1, $2, $3, $4) {
             var subName = $1 || $2,

--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -85,6 +85,7 @@ module.exports = function(XRegExp) {
      */
     XRegExp.build = function(pattern, subs, flags) {
         var inlineFlags = /^\(\?([\w$]+)\)/.exec(pattern),
+            asXRegExpFlags = (flags || '').indexOf('x') > -1 ? 'x' : '',
             data = {},
             numCaps = 0, // 'Caps' is short for captures
             numPriorCaps,
@@ -109,7 +110,7 @@ module.exports = function(XRegExp) {
                 // lest an unescaped `(`, `)`, `[`, or trailing `\` breaks the `(?:)` wrapper. For
                 // subpatterns provided as native regexes, it dies on octals and adds the property
                 // used to hold extended regex instance data, for simplicity
-                sub = asXRegExp(subs[p]);
+                sub = asXRegExp(subs[p], asXRegExpFlags);
                 data[p] = {
                     // Deanchoring allows embedding independently useful anchored regexes. If you
                     // really need to keep your anchors, double them (i.e., `^^...$$`)
@@ -121,7 +122,7 @@ module.exports = function(XRegExp) {
 
         // Passing to XRegExp dies on octals and ensures the outer pattern is independently valid;
         // helps keep this simple. Named captures will be put back
-        pattern = asXRegExp(pattern, flags);
+        pattern = asXRegExp(pattern, asXRegExpFlags);
         outerCapNames = pattern[REGEX_DATA].captureNames || [];
         pattern = pattern.source.replace(parts, function($0, $1, $2, $3, $4) {
             var subName = $1 || $2,

--- a/tests/spec/s-addons-build.js
+++ b/tests/spec/s-addons-build.js
@@ -10,6 +10,7 @@ describe('XRegExp.build addon:', function() {
 
         it('should ignore newlines when "x" flag is passed', function() {
             expect(XRegExp.build("\n", {}, 'x').test('')).toBe(true);
+            expect(XRegExp.build("{{sub}}", {sub: "\n"}, "x").test('')).toBe(true);
         });
 
         it('should apply a mode modifier with a native flag in the outer pattern to the final result', function() {

--- a/tests/spec/s-addons-build.js
+++ b/tests/spec/s-addons-build.js
@@ -8,6 +8,10 @@ describe('XRegExp.build addon:', function() {
             expect(function() {XRegExp.build('(?x)({{a}})', {a: /#/});}).toThrow();
         });
 
+        it('should ignore newlines when "x" flag is passed', function() {
+            expect(XRegExp.build("\n", {}, 'x').test('')).toBe(true);
+        });
+
         it('should apply a mode modifier with a native flag in the outer pattern to the final result', function() {
             expect(XRegExp.build('(?m){{a}}', {a: /a/}).multiline).toBe(true);
             expect(XRegExp.build('(?i){{a}}', {a: /a/}).ignoreCase).toBe(true);

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -39,22 +39,24 @@ module.exports = function(XRegExp) {
     }
 
     /**
-     * Converts the provided value to an XRegExp. Native RegExp flags are not preserved.
+     * Converts the provided value to an XRegExp. Native RegExp flags are not preserved. Flags can
+     * be provided as a separate argument.
      *
      * @private
      * @param {String|RegExp} value Value to convert.
+     * @param {String} [flags] Any combination of XRegExp flags.
      * @returns {RegExp} XRegExp object with XRegExp syntax applied.
      */
-    function asXRegExp(value) {
+    function asXRegExp(value, flags) {
         return XRegExp.isRegExp(value) ?
             (value[REGEX_DATA] && value[REGEX_DATA].captureNames ?
                 // Don't recompile, to preserve capture names
                 value :
                 // Recompile as XRegExp
-                XRegExp(value.source)
+                XRegExp(value.source, flags)
             ) :
             // Compile string as XRegExp
-            XRegExp(value);
+            XRegExp(value, flags);
     }
 
     /**
@@ -120,7 +122,7 @@ module.exports = function(XRegExp) {
 
         // Passing to XRegExp dies on octals and ensures the outer pattern is independently valid;
         // helps keep this simple. Named captures will be put back
-        pattern = asXRegExp(pattern);
+        pattern = asXRegExp(pattern, flags);
         outerCapNames = pattern[REGEX_DATA].captureNames || [];
         pattern = pattern.source.replace(parts, function($0, $1, $2, $3, $4) {
             var subName = $1 || $2,

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -86,6 +86,12 @@ module.exports = function(XRegExp) {
      */
     XRegExp.build = function(pattern, subs, flags) {
         var inlineFlags = /^\(\?([\w$]+)\)/.exec(pattern),
+            // These flags will be passed to the asXRegExp calls for `pattern` and for every
+            // subpattern in `subs`. This is to work around the following browser bugs:
+            //
+            // * Firefox converts '\n' to a regex that contains the literal characters \ and n
+            //   You can verify this by running `console.log(RegExp('\n').source)`
+            //   See here for more details: https://github.com/slevithan/xregexp/pull/163
             asXRegExpFlags = (flags || '').indexOf('x') > -1 ? 'x' : '',
             data = {},
             numCaps = 0, // 'Caps' is short for captures

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -86,6 +86,7 @@ module.exports = function(XRegExp) {
      */
     XRegExp.build = function(pattern, subs, flags) {
         var inlineFlags = /^\(\?([\w$]+)\)/.exec(pattern),
+            asXRegExpFlags = (flags || '').indexOf('x') > -1 ? 'x' : '',
             data = {},
             numCaps = 0, // 'Caps' is short for captures
             numPriorCaps,
@@ -110,7 +111,7 @@ module.exports = function(XRegExp) {
                 // lest an unescaped `(`, `)`, `[`, or trailing `\` breaks the `(?:)` wrapper. For
                 // subpatterns provided as native regexes, it dies on octals and adds the property
                 // used to hold extended regex instance data, for simplicity
-                sub = asXRegExp(subs[p]);
+                sub = asXRegExp(subs[p], asXRegExpFlags);
                 data[p] = {
                     // Deanchoring allows embedding independently useful anchored regexes. If you
                     // really need to keep your anchors, double them (i.e., `^^...$$`)
@@ -122,7 +123,7 @@ module.exports = function(XRegExp) {
 
         // Passing to XRegExp dies on octals and ensures the outer pattern is independently valid;
         // helps keep this simple. Named captures will be put back
-        pattern = asXRegExp(pattern, flags);
+        pattern = asXRegExp(pattern, asXRegExpFlags);
         outerCapNames = pattern[REGEX_DATA].captureNames || [];
         pattern = pattern.source.replace(parts, function($0, $1, $2, $3, $4) {
             var subName = $1 || $2,


### PR DESCRIPTION
This fixes https://github.com/slevithan/xregexp/issues/162 by making
sure that all the flags passed to `XRegExp.build` make it to the
`XRegExp()` call, rather than just the flags used as leading mode
modifiers in the pattern.