### PR TITLE
Cleanup (?:) from beginning/end of groups

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -332,7 +332,7 @@ function isPatternNext(pattern, pos, flags, needlePattern) {
         // Ignore any leading inline comments
         [inlineCommentPattern];
     return nativ.test.call(
-        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
+        new RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1775,7 +1775,10 @@ XRegExp.addToken(
     function(match, scope, flags) {
         // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
         // inadvertedly changing `\1(?#)1` to `\11`.
-        return isQuantifierNext(match.input, match.index + match[0].length, flags) ?
+        return (
+            match.input.charAt(match.index - 1) === '(' ||
+            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
+            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
             '' : '(?:)';
     },
     {leadChar: '('}
@@ -1789,7 +1792,10 @@ XRegExp.addToken(
     function(match, scope, flags) {
         // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
         // inadvertedly changing `\1 1` to `\11`.
-        return isQuantifierNext(match.input, match.index + match[0].length, flags) ?
+        return (
+            match.input.charAt(match.index - 1) === '(' ||
+            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
+            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
             '' : '(?:)';
     },
     {flag: 'x'}

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1772,15 +1772,7 @@ XRegExp.addToken(
  */
 XRegExp.addToken(
     /\(\?#[^)]*\)/,
-    function(match, scope, flags) {
-        // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
-        // inadvertedly changing `\1(?#)1` to `\11`.
-        return (
-            match.input.charAt(match.index - 1) === '(' ||
-            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
-            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
-            '' : '(?:)';
-    },
+    getCommentOrWhitespaceSeparator,
     {leadChar: '('}
 );
 
@@ -1789,17 +1781,31 @@ XRegExp.addToken(
  */
 XRegExp.addToken(
     /\s+|#[^\n]*\n?/,
-    function(match, scope, flags) {
-        // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
-        // inadvertedly changing `\1 1` to `\11`.
-        return (
-            match.input.charAt(match.index - 1) === '(' ||
-            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
-            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
-            '' : '(?:)';
-    },
+    getCommentOrWhitespaceSeparator,
     {flag: 'x'}
 );
+
+/**
+ * Returns a pattern that can be used in a native RegExp instead of a comment or whitespace.
+ * Depending on the context of the match, this can be either '' or '(?:)'.
+ *
+ * @private
+ * @param {String} match Match object for inline comments, whitespace, or line comments
+ * @param {String} scope (unused)
+ * @param {String} flags Flags used in the match
+ * @returns {String} Either '' or '(?:)', depending on which is needed in the context of the match.
+ */
+function getCommentOrWhitespaceSeparator (match, scope, flags) {
+    return (
+        // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
+        // inadvertedly changing `\1 1` or `\1(?#)1` to `\11`
+        isQuantifierNext(match.input, match.index + match[0].length, flags) ||
+        // If the match is at the beginning or end of a group,
+        // we don't need to insert an empty non-capturing group.
+        match.input.charAt(match.index - 1) === '(' ||
+        isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
+        '' : '(?:)';
+}
 
 /*
  * Dot, in dotall mode (aka singleline mode, flag s) only.

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -308,16 +308,31 @@ function isType(value, type) {
  * @returns {Boolean} Whether the next token is a quantifier.
  */
 function isQuantifierNext(pattern, pos, flags) {
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
+    return isPatternNext(pattern, pos, flags, quantifierPattern);
+}
+
+/**
+ * Checks whether the next nonignorable token after the specified position matches the
+ * `needlePattern`
+ *
+ * @private
+ * @param {String} pattern Pattern to search within.
+ * @param {Number} pos Index in `pattern` to search at.
+ * @param {String} flags Flags used by the pattern.
+ * @param {String} needlePattern Pattern to match the next token against.
+ * @returns {Boolean} Whether the next token matches `needlePattern`
+ */
+function isPatternNext(pattern, pos, flags, needlePattern) {
     var inlineCommentPattern = '\\(\\?#[^)]*\\)';
     var lineCommentPattern = '#[^#\\n]*';
-    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
     var patternsToIgnore = flags.indexOf('x') > -1 ?
         // Ignore any leading whitespace, line comments, and inline comments
         ['\\s', lineCommentPattern, inlineCommentPattern] :
         // Ignore any leading inline comments
         [inlineCommentPattern];
     return nativ.test.call(
-        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + quantifierPattern + ')'),
+        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -308,12 +308,16 @@ function isType(value, type) {
  * @returns {Boolean} Whether the next token is a quantifier.
  */
 function isQuantifierNext(pattern, pos, flags) {
+    var inlineCommentPattern = '\\(\\?#[^)]*\\)';
+    var lineCommentPattern = '#[^#\\n]*';
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
+    var patternsToIgnore = flags.indexOf('x') > -1 ?
+        // Ignore any leading whitespace, line comments, and inline comments
+        ['\\s', lineCommentPattern, inlineCommentPattern] :
+        // Ignore any leading inline comments
+        [inlineCommentPattern];
     return nativ.test.call(
-        flags.indexOf('x') > -1 ?
-            // Ignore any leading whitespace, line comments, and inline comments
-            /^(?:\s|#[^#\n]*|\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/ :
-            // Ignore any leading inline comments
-            /^(?:\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/,
+        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + quantifierPattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -182,6 +182,19 @@ describe('XRegExp()', function() {
         expect(function() {XRegExp('(\\(?:)');}).not.toThrow();
     });
 
+    it('should not put (?:) at beginning/end of groups', function() {
+        var regex = XRegExp('( [0-9]{4} ) -?  # year  \n' +
+                            '( [0-9]{2} ) -?  # month \n' +
+                            '( [0-9]{2} )     # day     ', 'x');
+        expect(regex.source).toEqual('([0-9]{4})(?:)-?(?:)([0-9]{2})(?:)-?(?:)([0-9]{2})(?:)');
+    });
+
+    it('should leave escaped (?:) at end of group', function() {
+        var regex = XRegExp('(.(\\(?:))');
+        expect(regex.test('x:')).toBe(true);
+        expect(regex.test('x(:')).toBe(true);
+    });
+
     it('should store named capture data on regex instances', function() {
         // The `captureNames` property is undocumented, so this is technically just testing
         // implementation details. However, any changes to this need to be very intentional

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2983,7 +2983,7 @@ function isPatternNext(pattern, pos, flags, needlePattern) {
         // Ignore any leading inline comments
         [inlineCommentPattern];
     return nativ.test.call(
-        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
+        new RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2959,16 +2959,31 @@ function isType(value, type) {
  * @returns {Boolean} Whether the next token is a quantifier.
  */
 function isQuantifierNext(pattern, pos, flags) {
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
+    return isPatternNext(pattern, pos, flags, quantifierPattern);
+}
+
+/**
+ * Checks whether the next nonignorable token after the specified position matches the
+ * `needlePattern`
+ *
+ * @private
+ * @param {String} pattern Pattern to search within.
+ * @param {Number} pos Index in `pattern` to search at.
+ * @param {String} flags Flags used by the pattern.
+ * @param {String} needlePattern Pattern to match the next token against.
+ * @returns {Boolean} Whether the next token matches `needlePattern`
+ */
+function isPatternNext(pattern, pos, flags, needlePattern) {
     var inlineCommentPattern = '\\(\\?#[^)]*\\)';
     var lineCommentPattern = '#[^#\\n]*';
-    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
     var patternsToIgnore = flags.indexOf('x') > -1 ?
         // Ignore any leading whitespace, line comments, and inline comments
         ['\\s', lineCommentPattern, inlineCommentPattern] :
         // Ignore any leading inline comments
         [inlineCommentPattern];
     return nativ.test.call(
-        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + quantifierPattern + ')'),
+        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2959,12 +2959,16 @@ function isType(value, type) {
  * @returns {Boolean} Whether the next token is a quantifier.
  */
 function isQuantifierNext(pattern, pos, flags) {
+    var inlineCommentPattern = '\\(\\?#[^)]*\\)';
+    var lineCommentPattern = '#[^#\\n]*';
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
+    var patternsToIgnore = flags.indexOf('x') > -1 ?
+        // Ignore any leading whitespace, line comments, and inline comments
+        ['\\s', lineCommentPattern, inlineCommentPattern] :
+        // Ignore any leading inline comments
+        [inlineCommentPattern];
     return nativ.test.call(
-        flags.indexOf('x') > -1 ?
-            // Ignore any leading whitespace, line comments, and inline comments
-            /^(?:\s|#[^#\n]*|\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/ :
-            // Ignore any leading inline comments
-            /^(?:\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/,
+        RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + quantifierPattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -4426,7 +4426,10 @@ XRegExp.addToken(
     function(match, scope, flags) {
         // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
         // inadvertedly changing `\1(?#)1` to `\11`.
-        return isQuantifierNext(match.input, match.index + match[0].length, flags) ?
+        return (
+            match.input.charAt(match.index - 1) === '(' ||
+            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
+            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
             '' : '(?:)';
     },
     {leadChar: '('}
@@ -4440,7 +4443,10 @@ XRegExp.addToken(
     function(match, scope, flags) {
         // Keep tokens separated unless the following token is a quantifier. This avoids e.g.
         // inadvertedly changing `\1 1` to `\11`.
-        return isQuantifierNext(match.input, match.index + match[0].length, flags) ?
+        return (
+            match.input.charAt(match.index - 1) === '(' ||
+            isQuantifierNext(match.input, match.index + match[0].length, flags) ||
+            isPatternNext(match.input, match.index + match[0].length, flags, '\\)')) ?
             '' : '(?:)';
     },
     {flag: 'x'}


### PR DESCRIPTION
This simplifies the compiled expressions by ensuring that groups don't
start or end with `(?:)`. For instance, this code:

```js
// Using named capture and flag x (free-spacing and line comments)
date = XRegExp('(?<year>  [0-9]{4} ) -?  # year  \n' +
               '(?<month> [0-9]{2} ) -?  # month \n' +
               '(?<day>   [0-9]{2} )     # day     ', 'x');
```

now compiles to this pattern:

```regex
([0-9]{4})(?:)-?(?:)([0-9]{2})(?:)-?(?:)([0-9]{2})(?:)
```

instead of

```regex
((?:)[0-9]{4}(?:))(?:)-?(?:)((?:)[0-9]{2}(?:))(?:)-?(?:)((?:)[0-9]{2}(?:))(?:)
```

Here are the two patterns side by side, with whitespace inserted into the new one to illustrate the differences:

```regex
(    [0-9]{4}    )(?:)-?(?:)(    [0-9]{2}    )(?:)-?(?:)(    [0-9]{2}    )(?:)
((?:)[0-9]{4}(?:))(?:)-?(?:)((?:)[0-9]{2}(?:))(?:)-?(?:)((?:)[0-9]{2}(?:))(?:)
```