### PR TITLE
Include build package in package.json for npm installs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "regular expression",
     "unicode"
   ],
-  "main": "./src/index.js",
+  "main": "xregexp-all.js",
   "files": [
     "src",
-    "xregexp-all.js"
+    "xregexp-all.js",
+    "LICENSE"
   ],
   "scripts": {
     "build": "browserify src/index.js --standalone XRegExp > xregexp-all.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "main": "./src/index.js",
   "files": [
-    "src"
+    "src",
+    "xregexp-all.js"
   ],
   "scripts": {
     "build": "browserify src/index.js --standalone XRegExp > xregexp-all.js",


### PR DESCRIPTION
While `xregexp-all.js` exists in the repo, it isn't included in the npm install. Adding the file to the package.json ensures npm installs provide a production-ready version for non-node applications.

This PR fixes #139 