### PR TITLE
Revert "Work around bug in Safari Technology Preview /y support -- closes #135"

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -72,10 +72,6 @@ function hasNativeFlag(flag) {
     } catch (exception) {
         isSupported = false;
     }
-    if (isSupported && flag === 'y') {
-        // Work around Safari 9.1.1 bug
-        return new RegExp('aa|.', 'y').test('b');
-    }
     return isSupported;
 }
 // Check for ES6 `u` flag support

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2723,10 +2723,6 @@ function hasNativeFlag(flag) {
     } catch (exception) {
         isSupported = false;
     }
-    if (isSupported && flag === 'y') {
-        // Work around Safari 9.1.1 bug
-        return new RegExp('aa|.', 'y').test('b');
-    }
     return isSupported;
 }
 // Check for ES6 `u` flag support


### PR DESCRIPTION
Closes https://github.com/slevithan/xregexp/issues/158

This reverts commit 660f3acd8d81b9282d12385205fca0a7e07e222a.