### PR TITLE
Add `conjunction` option for XRegExp.union and allow setting to 'none'

### DIFF
--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -10,7 +10,9 @@ module.exports = function(XRegExp) {
 
     var REGEX_DATA = 'xregexp';
     var subParts = /(\()(?!\?)|\\([1-9]\d*)|\\[\s\S]|\[(?:[^\\\]]|\\[\s\S])*\]/g;
-    var parts = XRegExp.union([/\({{([\w$]+)}}\)|{{([\w$]+)}}/, subParts], 'g');
+    var parts = XRegExp.union([/\({{([\w$]+)}}\)|{{([\w$]+)}}/, subParts], 'g', {
+        conjunction: 'or'
+    });
 
     /**
      * Strips a leading `^` and trailing unescaped `$`, if both are present.

--- a/src/addons/matchrecursive.js
+++ b/src/addons/matchrecursive.js
@@ -101,7 +101,7 @@ module.exports = function(XRegExp) {
             // Using `XRegExp.union` safely rewrites backreferences in `left` and `right`
             esc = new RegExp(
                 '(?:' + escapeChar + '[\\S\\s]|(?:(?!' +
-                    XRegExp.union([left, right]).source +
+                    XRegExp.union([left, right], basicFlags, {conjunction: 'or'}).source +
                     ')[^' + escapeChar + '])+)+',
                 // Flags `gy` not needed here
                 flags.replace(/[^imu]+/g, '')

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1322,13 +1322,21 @@ XRegExp.uninstall = function(options) {
  * @memberOf XRegExp
  * @param {Array} patterns Regexes and strings to combine.
  * @param {String} [flags] Any combination of XRegExp flags.
+ * @param {Object} [options] Options object with optional properties:
+ *   <li>`conjunction` {String} Type of conjunction to use: 'or' (default) or 'none'.
  * @returns {RegExp} Union of the provided regexes and strings.
  * @example
  *
  * XRegExp.union(['a+b*c', /(dogs)\1/, /(cats)\1/], 'i');
  * // -> /a\+b\*c|(dogs)\1|(cats)\2/i
+ *
+ * XRegExp.union([/man/, /bear/, /pig/], 'i', {conjunction: 'none'});
+ * // -> /manbearpig/i
  */
-XRegExp.union = function(patterns, flags) {
+XRegExp.union = function(patterns, flags, options) {
+    options = options || {};
+    var conjunction = options.conjunction || 'or';
+
     var numCaptures = 0;
     var numPriorCaptures;
     var captureNames;
@@ -1374,7 +1382,8 @@ XRegExp.union = function(patterns, flags) {
         }
     }
 
-    return XRegExp(output.join('|'), flags);
+    var separator = conjunction === 'none' ? '' : '|';
+    return XRegExp(output.join(separator), flags);
 };
 
 // ==--------------------------==

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -1691,6 +1691,25 @@ describe('XRegExp.union()', function() {
         expect(XRegExp.union([/x/g]).global).toBe(false);
     });
 
+    it('should set default conjunction to "or"', function() {
+        var regex = XRegExp.union([/man/, /bear/, /pig/], 'i');
+        expect('man'.match(regex)).toEqualMatch(['man']);
+        expect('bear'.match(regex)).toEqualMatch(['bear']);
+        expect('pig'.match(regex)).toEqualMatch(['pig']);
+    });
+
+    it('should allow setting conjunction to "or"', function() {
+        var regex = XRegExp.union([/man/, /bear/, /pig/], 'i', {conjunction: 'or'});
+        expect('man'.match(regex)).toEqualMatch(['man']);
+        expect('bear'.match(regex)).toEqualMatch(['bear']);
+        expect('pig'.match(regex)).toEqualMatch(['pig']);
+    });
+
+    it('should allow setting conjunction to "none"', function() {
+        var regex = XRegExp.union([/man/, /bear/, /pig/], 'i', {conjunction: 'none'});
+        expect('manbearpig'.match(regex)).toEqualMatch(['manbearpig']);
+    });
+
     it('should throw an exception when the same group name appears in separate regexes', function() {
         expect(function() {XRegExp.union([
             XRegExp('(?<pet>dogs)\\k<pet>'),

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -11,7 +11,9 @@ module.exports = function(XRegExp) {
 
     var REGEX_DATA = 'xregexp';
     var subParts = /(\()(?!\?)|\\([1-9]\d*)|\\[\s\S]|\[(?:[^\\\]]|\\[\s\S])*\]/g;
-    var parts = XRegExp.union([/\({{([\w$]+)}}\)|{{([\w$]+)}}/, subParts], 'g');
+    var parts = XRegExp.union([/\({{([\w$]+)}}\)|{{([\w$]+)}}/, subParts], 'g', {
+        conjunction: 'or'
+    });
 
     /**
      * Strips a leading `^` and trailing unescaped `$`, if both are present.
@@ -298,7 +300,7 @@ module.exports = function(XRegExp) {
             // Using `XRegExp.union` safely rewrites backreferences in `left` and `right`
             esc = new RegExp(
                 '(?:' + escapeChar + '[\\S\\s]|(?:(?!' +
-                    XRegExp.union([left, right]).source +
+                    XRegExp.union([left, right], basicFlags, {conjunction: 'or'}).source +
                     ')[^' + escapeChar + '])+)+',
                 // Flags `gy` not needed here
                 flags.replace(/[^imu]+/g, '')
@@ -3973,13 +3975,21 @@ XRegExp.uninstall = function(options) {
  * @memberOf XRegExp
  * @param {Array} patterns Regexes and strings to combine.
  * @param {String} [flags] Any combination of XRegExp flags.
+ * @param {Object} [options] Options object with optional properties:
+ *   <li>`conjunction` {String} Type of conjunction to use: 'or' (default) or 'none'.
  * @returns {RegExp} Union of the provided regexes and strings.
  * @example
  *
  * XRegExp.union(['a+b*c', /(dogs)\1/, /(cats)\1/], 'i');
  * // -> /a\+b\*c|(dogs)\1|(cats)\2/i
+ *
+ * XRegExp.union([/man/, /bear/, /pig/], 'i', {conjunction: 'none'});
+ * // -> /manbearpig/i
  */
-XRegExp.union = function(patterns, flags) {
+XRegExp.union = function(patterns, flags, options) {
+    options = options || {};
+    var conjunction = options.conjunction || 'or';
+
     var numCaptures = 0;
     var numPriorCaptures;
     var captureNames;
@@ -4025,7 +4035,8 @@ XRegExp.union = function(patterns, flags) {
         }
     }
 
-    return XRegExp(output.join('|'), flags);
+    var separator = conjunction === 'none' ? '' : '|';
+    return XRegExp(output.join(separator), flags);
 };
 
 // ==--------------------------==


### PR DESCRIPTION
The `XRegExp.union` calls in the `build` and `matchRecursive` addons are
also updated to explicitly specify `{conjunction: 'or'}`.

Fixes https://github.com/slevithan/xregexp/issues/106