### PR TITLE
Add $<n> and $<name> as alternative backreference syntax in replacement text

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -51,7 +51,10 @@ var nativeTokens = {
     'class': /\\(?:[0-3][0-7]{0,2}|[4-7][0-7]?|x[\dA-Fa-f]{2}|u(?:[\dA-Fa-f]{4}|{[\dA-Fa-f]+})|c[A-Za-z]|[\s\S])|[\s\S]/
 };
 // Any backreference or dollar-prefixed character in replacement strings
-var replacementToken = /\$(?:{([\w$]+)}|(\d\d?|[\s\S]))/g;
+var replacementTokens = [
+    /\$(?:<([\w$]+)>)/g,
+    /\$(?:{([\w$]+)}|(\d\d?|[\s\S]))/g
+];
 // Check for correct `exec` handling of nonparticipating capturing groups
 var correctExecNpcg = nativ.exec.call(/()??/, '')[1] === undefined;
 // Check for ES6 `flags` prop support
@@ -1590,7 +1593,9 @@ fixed.replace = function(search, replacement) {
         result = nativ.replace.call(this == null ? this : String(this), search, function() {
             // Keep this function's `arguments` available through closure
             var args = arguments;
-            return nativ.replace.call(String(replacement), replacementToken, replacer);
+            return replacementTokens.reduce(function (replacement, replacementToken) {
+                return nativ.replace.call(String(replacement), replacementToken, replacer);
+            }, replacement);
 
             function replacer ($0, $1, $2) {
                 var n;

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1592,11 +1592,11 @@ fixed.replace = function(search, replacement) {
             var args = arguments;
             return nativ.replace.call(String(replacement), replacementToken, replacer);
 
-            function replacer ($0, $1, $2, $3) {
-                $1 = $1 || $2
+            function replacer ($0, bracketed, angled, dollarToken) {
+                bracketed = bracketed || angled
                 var n;
                 // Named or numbered backreference with curly braces
-                if ($1) {
+                if (bracketed) {
                     // XRegExp behavior for `${n}` or `$<n>`:
                     // 1. Backreference to numbered capture, if `n` is an integer. Use `0` for the
                     //    entire match. Any number of leading zeros may be used.
@@ -1606,32 +1606,32 @@ fixed.replace = function(search, replacement) {
                     //    integer as the name.
                     // 3. If the name or number does not refer to an existing capturing group, it's
                     //    an error.
-                    n = +$1; // Type-convert; drop leading zeros
+                    n = +bracketed; // Type-convert; drop leading zeros
                     if (n <= args.length - 3) {
                         return args[n] || '';
                     }
                     // Groups with the same name is an error, else would need `lastIndexOf`
-                    n = captureNames ? indexOf(captureNames, $1) : -1;
+                    n = captureNames ? indexOf(captureNames, bracketed) : -1;
                     if (n < 0) {
                         throw new SyntaxError('Backreference to undefined group ' + $0);
                     }
                     return args[n + 1] || '';
                 }
                 // Else, special variable or numbered backreference without curly braces
-                if ($3 === '$') { // $$
+                if (dollarToken === '$') { // $$
                     return '$';
                 }
-                if ($3 === '&' || +$3 === 0) { // $&, $0 (not followed by 1-9), $00
+                if (dollarToken === '&' || +dollarToken === 0) { // $&, $0 (not followed by 1-9), $00
                     return args[0];
                 }
-                if ($3 === '`') { // $` (left context)
+                if (dollarToken === '`') { // $` (left context)
                     return args[args.length - 1].slice(0, args[args.length - 2]);
                 }
-                if ($3 === "'") { // $' (right context)
+                if (dollarToken === "'") { // $' (right context)
                     return args[args.length - 1].slice(args[args.length - 2] + args[0].length);
                 }
                 // Else, numbered backreference without curly braces
-                $3 = +$3; // Type-convert; drop leading zero
+                dollarToken = +dollarToken; // Type-convert; drop leading zero
                 // XRegExp behavior for `$n` and `$nn`:
                 // - Backrefs end after 1 or 2 digits. Use `${..}` or `$<..>` for more digits.
                 // - `$1` is an error if no capturing groups.
@@ -1645,11 +1645,11 @@ fixed.replace = function(search, replacement) {
                 // - `$10` is `$1` followed by a literal `0` if less than 10 capturing groups.
                 // - `$01` is `$1` if at least one capturing group, else it's a literal `$01`.
                 // - `$0` is a literal `$0`.
-                if (!isNaN($3)) {
-                    if ($3 > args.length - 3) {
+                if (!isNaN(dollarToken)) {
+                    if (dollarToken > args.length - 3) {
                         throw new SyntaxError('Backreference to undefined group ' + $0);
                     }
-                    return args[$3] || '';
+                    return args[dollarToken] || '';
                 }
                 // `$` followed by an unsupported char is an error, unlike native JS
                 throw new SyntaxError('Invalid token ' + $0);

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1138,9 +1138,9 @@ XRegExp.matchChain = function(str, chain) {
  * Returns a new string with one or all matches of a pattern replaced. The pattern can be a string
  * or regex, and the replacement can be a string or a function to be called for each match. To
  * perform a global search and replace, use the optional `scope` argument or include flag g if using
- * a regex. Replacement strings can use `${n}` for named and numbered backreferences. Replacement
- * functions can use named backreferences via `arguments[0].name`. Also fixes browser bugs compared
- * to the native `String.prototype.replace` and can be used reliably cross-browser.
+ * a regex. Replacement strings can use `${n}` or `$<n>` for named and numbered backreferences.
+ * Replacement functions can use named backreferences via `arguments[0].name`. Also fixes browser
+ * bugs compared to the native `String.prototype.replace` and can be used reliably cross-browser.
  *
  * @memberOf XRegExp
  * @param {String} str String to search.
@@ -1154,6 +1154,8 @@ XRegExp.matchChain = function(str, chain) {
  *     - $n, $nn - Where n/nn are digits referencing an existent capturing group, inserts
  *       backreference n/nn.
  *     - ${n} - Where n is a name or any number of digits that reference an existent capturing
+ *       group, inserts backreference n.
+ *     - $<n> - Where n is a name or any number of digits that reference an existent capturing
  *       group, inserts backreference n.
  *   Replacement functions are invoked with three or more arguments:
  *     - The matched substring (corresponds to $& above). Named backreferences are accessible as
@@ -1169,6 +1171,9 @@ XRegExp.matchChain = function(str, chain) {
  * // Regex search, using named backreferences in replacement string
  * var name = XRegExp('(?<first>\\w+) (?<last>\\w+)');
  * XRegExp.replace('John Smith', name, '${last}, ${first}');
+ * // -> 'Smith, John'
+ *
+ * XRegExp.replace('John Smith', name, '$<last>, $<first>');
  * // -> 'Smith, John'
  *
  * // Regex search, using named backreferences in replacement function
@@ -1220,7 +1225,8 @@ XRegExp.replace = function(str, search, replacement, scope) {
  * array of replacement details. Later replacements operate on the output of earlier replacements.
  * Replacement details are accepted as an array with a regex or string to search for, the
  * replacement string or function, and an optional scope of 'one' or 'all'. Uses the XRegExp
- * replacement text syntax, which supports named backreference properties via `${name}`.
+ * replacement text syntax, which supports named backreference properties via `${name}` or
+ * `$<name>`.
  *
  * @memberOf XRegExp
  * @param {String} str String to search.
@@ -1523,13 +1529,13 @@ fixed.match = function(regex) {
 };
 
 /**
- * Adds support for `${n}` tokens for named and numbered backreferences in replacement text, and
- * provides named backreferences to replacement functions as `arguments[0].name`. Also fixes browser
- * bugs in replacement text syntax when performing a replacement using a nonregex search value, and
- * the value of a replacement regex's `lastIndex` property during replacement iterations and upon
- * completion. Calling `XRegExp.install('natives')` uses this to override the native method. Note
- * that this doesn't support SpiderMonkey's proprietary third (`flags`) argument. Use via
- * `XRegExp.replace` without overriding natives.
+ * Adds support for `${n}` (or `$<n>`) tokens for named and numbered backreferences in replacement
+ * text, and provides named backreferences to replacement functions as `arguments[0].name`. Also
+ * fixes browser bugs in replacement text syntax when performing a replacement using a nonregex
+ * search value, and the value of a replacement regex's `lastIndex` property during replacement
+ * iterations and upon completion. Calling `XRegExp.install('natives')` uses this to override the
+ * native method. Note that this doesn't support SpiderMonkey's proprietary third (`flags`)
+ * argument. Use via `XRegExp.replace` without overriding natives.
  *
  * @memberOf String
  * @param {RegExp|String} search Search pattern to be replaced.
@@ -1590,7 +1596,7 @@ fixed.replace = function(search, replacement) {
                 var n;
                 // Named or numbered backreference with curly braces
                 if ($1) {
-                    // XRegExp behavior for `${n}`:
+                    // XRegExp behavior for `${n}` or `$<n>`:
                     // 1. Backreference to numbered capture, if `n` is an integer. Use `0` for the
                     //    entire match. Any number of leading zeros may be used.
                     // 2. Backreference to named capture `n`, if it exists and is not an integer
@@ -1626,9 +1632,10 @@ fixed.replace = function(search, replacement) {
                 // Else, numbered backreference without curly braces
                 $2 = +$2; // Type-convert; drop leading zero
                 // XRegExp behavior for `$n` and `$nn`:
-                // - Backrefs end after 1 or 2 digits. Use `${..}` for more digits.
+                // - Backrefs end after 1 or 2 digits. Use `${..}` or `$<..>` for more digits.
                 // - `$1` is an error if no capturing groups.
-                // - `$10` is an error if less than 10 capturing groups. Use `${1}0` instead.
+                // - `$10` is an error if less than 10 capturing groups. Use `${1}0` or `$<1>0`
+                //   instead.
                 // - `$01` is `$1` if at least one capturing group, else it's an error.
                 // - `$0` (not followed by 1-9) and `$00` are the entire match.
                 // Native behavior, for comparison:

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1153,9 +1153,7 @@ XRegExp.matchChain = function(str, chain) {
  *     - $' - Inserts the string that follows the matched substring (right context).
  *     - $n, $nn - Where n/nn are digits referencing an existent capturing group, inserts
  *       backreference n/nn.
- *     - ${n} - Where n is a name or any number of digits that reference an existent capturing
- *       group, inserts backreference n.
- *     - $<n> - Where n is a name or any number of digits that reference an existent capturing
+ *     - ${n}, $<n> - Where n is a name or any number of digits that reference an existent capturing
  *       group, inserts backreference n.
  *   Replacement functions are invoked with three or more arguments:
  *     - The matched substring (corresponds to $& above). Named backreferences are accessible as

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1592,8 +1592,8 @@ fixed.replace = function(search, replacement) {
             var args = arguments;
             return nativ.replace.call(String(replacement), replacementToken, replacer);
 
-            function replacer ($0, bracketed, angled, dollarToken) {
-                bracketed = bracketed || angled
+            function replacer($0, bracketed, angled, dollarToken) {
+                bracketed = bracketed || angled;
                 var n;
                 // Named or numbered backreference with curly braces
                 if (bracketed) {

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1584,7 +1584,9 @@ fixed.replace = function(search, replacement) {
         result = nativ.replace.call(this == null ? this : String(this), search, function() {
             // Keep this function's `arguments` available through closure
             var args = arguments;
-            return nativ.replace.call(String(replacement), replacementToken, function($0, $1, $2) {
+            return nativ.replace.call(String(replacement), replacementToken, replacer);
+
+            function replacer ($0, $1, $2) {
                 var n;
                 // Named or numbered backreference with curly braces
                 if ($1) {
@@ -1643,7 +1645,7 @@ fixed.replace = function(search, replacement) {
                 }
                 // `$` followed by an unsupported char is an error, unlike native JS
                 throw new SyntaxError('Invalid token ' + $0);
-            });
+            }
         });
     }
 

--- a/tests/spec/s-xregexp-natives.js
+++ b/tests/spec/s-xregexp-natives.js
@@ -588,6 +588,7 @@ describe('When overridden, String.prototype.replace()', function() {
 
                         expect('aabbcd'.replace(lottaGroups, '${0} ${01} ${001} ${0001} ${1} ${10} ${100} ${1000}')).toBe('aabbcd a a a a b c d');
                         expect('aabbcd'.replace(lottaGroups, '$<0> $<01> $<001> $<0001> $<1> $<10> $<100> $<1000>')).toBe('aabbcd a a a a b c d');
+                        expect('aabbcd'.replace(lottaGroups, '$<0> ${01} $<001> ${0001} $<1> ${10} $<100> ${1000}')).toBe('aabbcd a a a a b c d');
                         // For comparison...
                         expect('aabbcd'.replace(lottaGroups, '$0 $01 $001 $0001 $1 $10 $100 $1000')).toBe('aabbcd a aabbcd1 aabbcd01 a b b0 b00');
                     } catch (err) {

--- a/tests/spec/s-xregexp-natives.js
+++ b/tests/spec/s-xregexp-natives.js
@@ -508,13 +508,16 @@ describe('When overridden, String.prototype.replace()', function() {
 
                 it('should return the named backreference', function() {
                     expect('test'.replace(XRegExp('(?<test>t)', 'g'), ':${test}:')).toBe(':t:es:t:');
+                    expect('test'.replace(XRegExp('(?<test>t)', 'g'), ':$<test>:')).toBe(':t:es:t:');
 
                     // Backreference to a nonparticipating capturing group
                     expect('test'.replace(XRegExp('t|(?<test>t)', 'g'), ':${test}:')).toBe('::es::');
+                    expect('test'.replace(XRegExp('t|(?<test>t)', 'g'), ':$<test>:')).toBe('::es::');
                 });
 
                 it('should throw an exception for backreferences to unknown group names', function() {
                     expect(function() {'test'.replace(XRegExp('(?<test>t)', 'g'), ':${x}:');}).toThrowError(SyntaxError);
+                    expect(function() {'test'.replace(XRegExp('(?<test>t)', 'g'), ':$<x>:');}).toThrowError(SyntaxError);
                 });
 
             });
@@ -523,34 +526,51 @@ describe('When overridden, String.prototype.replace()', function() {
 
                 it('should return the numbered backreference', function() {
                     expect('test'.replace(/(.)./g, '${1}')).toBe('ts');
+                    expect('test'.replace(/(.)./g, '$<1>')).toBe('ts');
 
                     // Backreference to a nonparticipating capturing group
                     expect('test'.replace(/t|(e)/g, '${1}')).toBe('es');
+                    expect('test'.replace(/t|(e)/g, '$<1>')).toBe('es');
                 });
 
                 it('should allow leading zeros', function() {
                     expect('test'.replace(/(.)./g, '${01}')).toBe('ts');
+                    expect('test'.replace(/(.)./g, '$<01>')).toBe('ts');
+
                     expect('test'.replace(/(.)./g, '${001}')).toBe('ts');
+                    expect('test'.replace(/(.)./g, '$<001>')).toBe('ts');
                 });
 
                 it('should return named backreferences by number', function() {
                     expect('test'.replace(XRegExp('(?<name>.).', 'g'), '${1}')).toBe('ts');
+                    expect('test'.replace(XRegExp('(?<name>.).', 'g'), '$<1>')).toBe('ts');
                 });
 
                 it('should separate numbered backreferences from following literal digits', function() {
                     expect('test'.replace(new RegExp('(.).', 'g'), '${1}0')).toBe('t0s0');
+                    expect('test'.replace(new RegExp('(.).', 'g'), '$<1>0')).toBe('t0s0');
+
                     expect('test'.replace(new RegExp('(.).' + repeat('()', 9), 'g'), '${1}0')).toBe('t0s0');
+                    expect('test'.replace(new RegExp('(.).' + repeat('()', 9), 'g'), '$<1>0')).toBe('t0s0');
                 });
 
                 it('should throw an exception for backreferences to unknown group numbers', function() {
                     expect(function() {'test'.replace(/t/, '${1}');}).toThrowError(SyntaxError);
+                    expect(function() {'test'.replace(/t/, '$<1>');}).toThrowError(SyntaxError);
+
                     expect(function() {'test'.replace(/(t)/, '${2}');}).toThrowError(SyntaxError);
+                    expect(function() {'test'.replace(/(t)/, '$<2>');}).toThrowError(SyntaxError);
                 });
 
                 it('should allow ${0} to refer to the entire match', function() {
                     expect('test'.replace(/../g, '${0}:')).toBe('te:st:');
+                    expect('test'.replace(/../g, '$<0>:')).toBe('te:st:');
+
                     expect('test'.replace(/../g, '${00}:')).toBe('te:st:');
+                    expect('test'.replace(/../g, '$<00>:')).toBe('te:st:');
+
                     expect('test'.replace(/../g, '${000}:')).toBe('te:st:');
+                    expect('test'.replace(/../g, '$<000>:')).toBe('te:st:');
                 });
 
                 it('should support backreferences 100 and greater, if the browser does natively', function() {
@@ -567,6 +587,7 @@ describe('When overridden, String.prototype.replace()', function() {
                         ].join(''));
 
                         expect('aabbcd'.replace(lottaGroups, '${0} ${01} ${001} ${0001} ${1} ${10} ${100} ${1000}')).toBe('aabbcd a a a a b c d');
+                        expect('aabbcd'.replace(lottaGroups, '$<0> $<01> $<001> $<0001> $<1> $<10> $<100> $<1000>')).toBe('aabbcd a a a a b c d');
                         // For comparison...
                         expect('aabbcd'.replace(lottaGroups, '$0 $01 $001 $0001 $1 $10 $100 $1000')).toBe('aabbcd a aabbcd1 aabbcd01 a b b0 b00');
                     } catch (err) {

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -3842,7 +3842,9 @@ fixed.replace = function (search, replacement) {
         result = nativ.replace.call(this == null ? this : String(this), search, function () {
             // Keep this function's `arguments` available through closure
             var args = arguments;
-            return nativ.replace.call(String(replacement), replacementToken, function ($0, $1, $2) {
+            return nativ.replace.call(String(replacement), replacementToken, replacer);
+
+            function replacer($0, $1, $2) {
                 var n;
                 // Named or numbered backreference with curly braces
                 if ($1) {
@@ -3905,7 +3907,7 @@ fixed.replace = function (search, replacement) {
                 }
                 // `$` followed by an unsupported char is an error, unlike native JS
                 throw new SyntaxError('Invalid token ' + $0);
-            });
+            }
         });
     }
 

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -3850,11 +3850,11 @@ fixed.replace = function (search, replacement) {
             var args = arguments;
             return nativ.replace.call(String(replacement), replacementToken, replacer);
 
-            function replacer($0, $1, $2, $3) {
-                $1 = $1 || $2;
+            function replacer($0, bracketed, angled, dollarToken) {
+                bracketed = bracketed || angled;
                 var n;
                 // Named or numbered backreference with curly braces
-                if ($1) {
+                if (bracketed) {
                     // XRegExp behavior for `${n}` or `$<n>`:
                     // 1. Backreference to numbered capture, if `n` is an integer. Use `0` for the
                     //    entire match. Any number of leading zeros may be used.
@@ -3864,36 +3864,36 @@ fixed.replace = function (search, replacement) {
                     //    integer as the name.
                     // 3. If the name or number does not refer to an existing capturing group, it's
                     //    an error.
-                    n = +$1; // Type-convert; drop leading zeros
+                    n = +bracketed; // Type-convert; drop leading zeros
                     if (n <= args.length - 3) {
                         return args[n] || '';
                     }
                     // Groups with the same name is an error, else would need `lastIndexOf`
-                    n = captureNames ? indexOf(captureNames, $1) : -1;
+                    n = captureNames ? indexOf(captureNames, bracketed) : -1;
                     if (n < 0) {
                         throw new SyntaxError('Backreference to undefined group ' + $0);
                     }
                     return args[n + 1] || '';
                 }
                 // Else, special variable or numbered backreference without curly braces
-                if ($3 === '$') {
+                if (dollarToken === '$') {
                     // $$
                     return '$';
                 }
-                if ($3 === '&' || +$3 === 0) {
+                if (dollarToken === '&' || +dollarToken === 0) {
                     // $&, $0 (not followed by 1-9), $00
                     return args[0];
                 }
-                if ($3 === '`') {
+                if (dollarToken === '`') {
                     // $` (left context)
                     return args[args.length - 1].slice(0, args[args.length - 2]);
                 }
-                if ($3 === "'") {
+                if (dollarToken === "'") {
                     // $' (right context)
                     return args[args.length - 1].slice(args[args.length - 2] + args[0].length);
                 }
                 // Else, numbered backreference without curly braces
-                $3 = +$3; // Type-convert; drop leading zero
+                dollarToken = +dollarToken; // Type-convert; drop leading zero
                 // XRegExp behavior for `$n` and `$nn`:
                 // - Backrefs end after 1 or 2 digits. Use `${..}` or `$<..>` for more digits.
                 // - `$1` is an error if no capturing groups.
@@ -3907,11 +3907,11 @@ fixed.replace = function (search, replacement) {
                 // - `$10` is `$1` followed by a literal `0` if less than 10 capturing groups.
                 // - `$01` is `$1` if at least one capturing group, else it's a literal `$01`.
                 // - `$0` is a literal `$0`.
-                if (!isNaN($3)) {
-                    if ($3 > args.length - 3) {
+                if (!isNaN(dollarToken)) {
+                    if (dollarToken > args.length - 3) {
                         throw new SyntaxError('Backreference to undefined group ' + $0);
                     }
-                    return args[$3] || '';
+                    return args[dollarToken] || '';
                 }
                 // `$` followed by an unsupported char is an error, unlike native JS
                 throw new SyntaxError('Invalid token ' + $0);

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -3413,9 +3413,7 @@ XRegExp.matchChain = function (str, chain) {
  *     - $' - Inserts the string that follows the matched substring (right context).
  *     - $n, $nn - Where n/nn are digits referencing an existent capturing group, inserts
  *       backreference n/nn.
- *     - ${n} - Where n is a name or any number of digits that reference an existent capturing
- *       group, inserts backreference n.
- *     - $<n> - Where n is a name or any number of digits that reference an existent capturing
+ *     - ${n}, $<n> - Where n is a name or any number of digits that reference an existent capturing
  *       group, inserts backreference n.
  *   Replacement functions are invoked with three or more arguments:
  *     - The matched substring (corresponds to $& above). Named backreferences are accessible as

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -91,8 +91,8 @@ module.exports = function (XRegExp) {
      * time.test('10:59'); // -> true
      * XRegExp.exec('10:59', time).minutes; // -> '59'
      */
-    XRegExp.tag = function(flags) {
-        return function(literals /*, ...substitutions */) {
+    XRegExp.tag = function (flags) {
+        return function (literals /*, ...substitutions */) {
             var substitutions = [].slice.call(arguments, 1);
             var subpatterns = substitutions.map(interpolate).reduce(reduceToSubpatternsObject, {});
             var pattern = literals.raw.map(embedSubpatternAfter).join('');

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2336,7 +2336,10 @@ var nativeTokens = {
     'class': /\\(?:[0-3][0-7]{0,2}|[4-7][0-7]?|x[\dA-Fa-f]{2}|u(?:[\dA-Fa-f]{4}|{[\dA-Fa-f]+})|c[A-Za-z]|[\s\S])|[\s\S]/
 };
 // Any backreference or dollar-prefixed character in replacement strings
-var replacementToken = /\$(?:{([\w$]+)}|(\d\d?|[\s\S]))/g;
+var replacementTokens = [
+    /\$(?:<([\w$]+)>)/g,
+    /\$(?:{([\w$]+)}|(\d\d?|[\s\S]))/g
+];
 // Check for correct `exec` handling of nonparticipating capturing groups
 var correctExecNpcg = nativ.exec.call(/()??/, '')[1] === undefined;
 // Check for ES6 `flags` prop support
@@ -3848,7 +3851,9 @@ fixed.replace = function (search, replacement) {
         result = nativ.replace.call(this == null ? this : String(this), search, function () {
             // Keep this function's `arguments` available through closure
             var args = arguments;
-            return nativ.replace.call(String(replacement), replacementToken, replacer);
+            return replacementTokens.reduce(function (replacement, replacementToken) {
+                return nativ.replace.call(String(replacement), replacementToken, replacer);
+            }, replacement);
 
             function replacer($0, $1, $2) {
                 var n;

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2336,10 +2336,7 @@ var nativeTokens = {
     'class': /\\(?:[0-3][0-7]{0,2}|[4-7][0-7]?|x[\dA-Fa-f]{2}|u(?:[\dA-Fa-f]{4}|{[\dA-Fa-f]+})|c[A-Za-z]|[\s\S])|[\s\S]/
 };
 // Any backreference or dollar-prefixed character in replacement strings
-var replacementTokens = [
-    /\$(?:<([\w$]+)>)/g,
-    /\$(?:{([\w$]+)}|(\d\d?|[\s\S]))/g
-];
+var replacementToken = /\$(?:{([\w$]+)}|<([\w$]+)>|(\d\d?|[\s\S]))/g;
 // Check for correct `exec` handling of nonparticipating capturing groups
 var correctExecNpcg = nativ.exec.call(/()??/, '')[1] === undefined;
 // Check for ES6 `flags` prop support
@@ -3851,11 +3848,10 @@ fixed.replace = function (search, replacement) {
         result = nativ.replace.call(this == null ? this : String(this), search, function () {
             // Keep this function's `arguments` available through closure
             var args = arguments;
-            return replacementTokens.reduce(function (replacement, replacementToken) {
-                return nativ.replace.call(String(replacement), replacementToken, replacer);
-            }, replacement);
+            return nativ.replace.call(String(replacement), replacementToken, replacer);
 
-            function replacer($0, $1, $2) {
+            function replacer($0, $1, $2, $3) {
+                $1 = $1 || $2;
                 var n;
                 // Named or numbered backreference with curly braces
                 if ($1) {
@@ -3880,24 +3876,24 @@ fixed.replace = function (search, replacement) {
                     return args[n + 1] || '';
                 }
                 // Else, special variable or numbered backreference without curly braces
-                if ($2 === '$') {
+                if ($3 === '$') {
                     // $$
                     return '$';
                 }
-                if ($2 === '&' || +$2 === 0) {
+                if ($3 === '&' || +$3 === 0) {
                     // $&, $0 (not followed by 1-9), $00
                     return args[0];
                 }
-                if ($2 === '`') {
+                if ($3 === '`') {
                     // $` (left context)
                     return args[args.length - 1].slice(0, args[args.length - 2]);
                 }
-                if ($2 === "'") {
+                if ($3 === "'") {
                     // $' (right context)
                     return args[args.length - 1].slice(args[args.length - 2] + args[0].length);
                 }
                 // Else, numbered backreference without curly braces
-                $2 = +$2; // Type-convert; drop leading zero
+                $3 = +$3; // Type-convert; drop leading zero
                 // XRegExp behavior for `$n` and `$nn`:
                 // - Backrefs end after 1 or 2 digits. Use `${..}` or `$<..>` for more digits.
                 // - `$1` is an error if no capturing groups.
@@ -3911,11 +3907,11 @@ fixed.replace = function (search, replacement) {
                 // - `$10` is `$1` followed by a literal `0` if less than 10 capturing groups.
                 // - `$01` is `$1` if at least one capturing group, else it's a literal `$01`.
                 // - `$0` is a literal `$0`.
-                if (!isNaN($2)) {
-                    if ($2 > args.length - 3) {
+                if (!isNaN($3)) {
+                    if ($3 > args.length - 3) {
                         throw new SyntaxError('Backreference to undefined group ' + $0);
                     }
-                    return args[$2] || '';
+                    return args[$3] || '';
                 }
                 // `$` followed by an unsupported char is an error, unlike native JS
                 throw new SyntaxError('Invalid token ' + $0);


### PR DESCRIPTION
Fixes https://github.com/slevithan/xregexp/issues/177

I had some trouble using a single regex for the replacement, so I replaced
the $<name> syntax first in a separate pass.