### PR TITLE
Revert isPatternNext to isQuantifierNext

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["transform-xregexp"],
   "presets": [["env", {
     "exclude": ["transform-es2015-literals"]
   }]]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-transform-xregexp": "^0.0.4",
     "babel-preset-env": "^1.4.0",
     "browserify": "^12.0.1",
     "jasmine": "^2.5.3"

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -241,7 +241,7 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input.charAt(match.index - 1) === '(' ||
         match.input.charAt(match.index + match[0].length) === ')' ||
         // Avoid separating tokens when the following token is a quantifier
-        isPatternNext(match.input, match.index + match[0].length, flags, '[?*+]|{\\d+(?:,\\d*)?}')
+        isQuantifierNext(match.input, match.index + match[0].length, flags)
     ) {
         return '';
     }
@@ -311,26 +311,24 @@ function indexOf(array, value) {
 }
 
 /**
- * Checks whether the next nonignorable token after the specified position matches the
- * `needlePattern`
+ * Checks whether the next nonignorable token after the specified position is a quantifier.
  *
  * @private
  * @param {String} pattern Pattern to search within.
  * @param {Number} pos Index in `pattern` to search at.
  * @param {String} flags Flags used by the pattern.
- * @param {String} needlePattern Pattern to match the next token against.
- * @returns {Boolean} Whether the next nonignorable token matches `needlePattern`
+ * @returns {Boolean} Whether the next nonignorable token is a quantifier.
  */
-function isPatternNext(pattern, pos, flags, needlePattern) {
+function isQuantifierNext(pattern, pos, flags) {
     var inlineCommentPattern = '\\(\\?#[^)]*\\)';
     var lineCommentPattern = '#[^#\\n]*';
-    var patternsToIgnore = flags.indexOf('x') > -1 ?
-        // Ignore any leading whitespace, line comments, and inline comments
-        ['\\s', lineCommentPattern, inlineCommentPattern] :
-        // Ignore any leading inline comments
-        [inlineCommentPattern];
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
     return nativ.test.call(
-        new RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'),
+        flags.indexOf('x') > -1 ?
+            // Ignore any leading whitespace, line comments, and inline comments
+            new RegExp('^(?:' + '\\s' + '|' + lineCommentPattern + '|' + inlineCommentPattern + ')*(?:' + quantifierPattern + ')') :
+            // Ignore any leading inline comments
+            new RegExp('^(?:' + inlineCommentPattern + ')*(?:' + quantifierPattern + ')'),
         pattern.slice(pos)
     );
 }

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2882,7 +2882,7 @@ function XRegExp(pattern, flags) {
 }
 
 // Add `RegExp.prototype` to the prototype chain
-XRegExp.prototype = new RegExp();
+XRegExp.prototype = /(?:)/;
 
 // ==--------------------------==
 // Public properties

--- a/xregexp-all.js
+++ b/xregexp-all.js
@@ -2486,7 +2486,7 @@ function getContextualTokenSeparator(match, scope, flags) {
     // No need to separate tokens if at the beginning or end of a group
     match.input.charAt(match.index - 1) === '(' || match.input.charAt(match.index + match[0].length) === ')' ||
     // Avoid separating tokens when the following token is a quantifier
-    isPatternNext(match.input, match.index + match[0].length, flags, '[?*+]|{\\d+(?:,\\d*)?}')) {
+    isQuantifierNext(match.input, match.index + match[0].length, flags)) {
         return '';
     }
     // Keep tokens separated. This avoids e.g. inadvertedly changing `\1 1` or `\1(?#)1` to `\11`.
@@ -2554,25 +2554,23 @@ function indexOf(array, value) {
 }
 
 /**
- * Checks whether the next nonignorable token after the specified position matches the
- * `needlePattern`
+ * Checks whether the next nonignorable token after the specified position is a quantifier.
  *
  * @private
  * @param {String} pattern Pattern to search within.
  * @param {Number} pos Index in `pattern` to search at.
  * @param {String} flags Flags used by the pattern.
- * @param {String} needlePattern Pattern to match the next token against.
- * @returns {Boolean} Whether the next nonignorable token matches `needlePattern`
+ * @returns {Boolean} Whether the next nonignorable token is a quantifier.
  */
-function isPatternNext(pattern, pos, flags, needlePattern) {
+function isQuantifierNext(pattern, pos, flags) {
     var inlineCommentPattern = '\\(\\?#[^)]*\\)';
     var lineCommentPattern = '#[^#\\n]*';
-    var patternsToIgnore = flags.indexOf('x') > -1 ?
+    var quantifierPattern = '[?*+]|{\\d+(?:,\\d*)?}';
+    return nativ.test.call(flags.indexOf('x') > -1 ?
     // Ignore any leading whitespace, line comments, and inline comments
-    ['\\s', lineCommentPattern, inlineCommentPattern] :
+    /^(?:\s|#[^#\n]*|\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/ :
     // Ignore any leading inline comments
-    [inlineCommentPattern];
-    return nativ.test.call(new RegExp('^(?:' + patternsToIgnore.join('|') + ')*(?:' + needlePattern + ')'), pattern.slice(pos));
+    /^(?:\(\?#[^)]*\))*(?:[?*+]|{\d+(?:,\d*)?})/, pattern.slice(pos));
 }
 
 /**


### PR DESCRIPTION
This makes the "Constructor with x flag, whitespace, and comments" test
fast again. From
https://github.com/slevithan/xregexp/pull/164#issuecomment-294345042:

> A couple ideas: avoid the string concatenation in `isPatternNext`
> (possibly going back to regex literals and making the function specific
> to quantifiers again even though the current code is more
> readable/maintainable, since this isn't needed to handle simple cases
> with whitespace followed by `)`)

Since [babel-plugin-transform-xregexp] automatically compiles the `new
RegExp()` calls into literals, we get (most of) the performance back
without sacrificing the readability of having separate subpatterns.

[babel-plugin-transform-xregexp]: https://www.npmjs.com/package/babel-plugin-transform-xregexp