### PR TITLE
Cleanup more `(?:)` from patterns

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -238,8 +238,8 @@ function getContextualTokenSeparator(match, scope, flags) {
         // No need to separate tokens if at the beginning or end of a group
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
-        // No need to separate tokens if at the beginning of a non-capturing group
-        match.input.slice(match.index - 3, 3) === '(?:' ||
+        // No need to separate tokens if at the beginning of a non-capturing group or lookahead
+        match.input.slice(match.index - 3, 3).match(/\(\?[:=!]/) ||
         // No need to separate tokens if before or after a `|`
         match.input[match.index - 1] === '|' ||
         match.input[match.index + match[0].length] === '|' ||

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -247,8 +247,8 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input[match.index - 1] === '|' ||
         match.input[match.index + match[0].length] === '|' ||
         // No need to separate tokens if at the beginning or end of the pattern
-        match.input[match.index - 1] === undefined ||
-        match.input[match.index + match[0].length] === undefined ||
+        match.index - 1 < 0 ||
+        match.index + match[0].length >= match.input.length ||
         // Avoid separating tokens when the following token is a quantifier
         isQuantifierNext(match.input, match.index + match[0].length, flags)
     ) {

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -238,6 +238,14 @@ function getContextualTokenSeparator(match, scope, flags) {
         // No need to separate tokens if at the beginning or end of a group
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
+        // No need to separate tokens if at the beginning of a non-capturing group
+        match.input.slice(match.index - 3, 3) === '(?:' ||
+        // No need to separate tokens if before or after a `|`
+        match.input[match.index - 1] === '|' ||
+        match.input[match.index + match[0].length] === '|' ||
+        // No need to separate tokens if at the beginning or end of the pattern
+        match.input[match.index - 1] === undefined ||
+        match.input[match.index + match[0].length] === undefined ||
         // Avoid separating tokens when the following token is a quantifier
         isQuantifierNext(match.input, match.index + match[0].length, flags)
     ) {

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -250,7 +250,7 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input[match.index + match[0].length] === '|' ||
 
         // No need to separate tokens if at the beginning or end of the pattern
-        match.index - 1 < 0 ||
+        match.index < 1 ||
         match.index + match[0].length >= match.input.length ||
 
         // Avoid separating tokens when the following token is a quantifier

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -239,7 +239,7 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
         // No need to separate tokens if at the beginning of a non-capturing group or lookahead
-        nativ.test.call(/\(\?[:=!]/, match.input.slice(match.index - 3, 3)) ||
+        nativ.test.call(/\(\?[:=!]/, match.input.substr(match.index - 3, 3)) ||
         // No need to separate tokens if before or after a `|`
         match.input[match.index - 1] === '|' ||
         match.input[match.index + match[0].length] === '|' ||

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -239,6 +239,9 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
         // No need to separate tokens if at the beginning of a non-capturing group or lookahead
+        //
+        // If `match.index - 3` is negative, the substring will be too short to match, so the test will fail.
+        // For example: '1234'.substr(-1, 3) === '4'
         nativ.test.call(/\(\?[:=!]/, match.input.substr(match.index - 3, 3)) ||
         // No need to separate tokens if before or after a `|`
         match.input[match.index - 1] === '|' ||

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -238,17 +238,21 @@ function getContextualTokenSeparator(match, scope, flags) {
         // No need to separate tokens if at the beginning or end of a group
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
+
         // No need to separate tokens if at the beginning of a non-capturing group or lookahead
         //
         // If `match.index - 3` is negative, the substring will be too short to match, so the test will fail.
         // For example: '1234'.substr(-1, 3) === '4'
         nativ.test.call(/\(\?[:=!]/, match.input.substr(match.index - 3, 3)) ||
+
         // No need to separate tokens if before or after a `|`
         match.input[match.index - 1] === '|' ||
         match.input[match.index + match[0].length] === '|' ||
+
         // No need to separate tokens if at the beginning or end of the pattern
         match.index - 1 < 0 ||
         match.index + match[0].length >= match.input.length ||
+
         // Avoid separating tokens when the following token is a quantifier
         isQuantifierNext(match.input, match.index + match[0].length, flags)
     ) {

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -239,7 +239,7 @@ function getContextualTokenSeparator(match, scope, flags) {
         match.input[match.index - 1] === '(' ||
         match.input[match.index + match[0].length] === ')' ||
         // No need to separate tokens if at the beginning of a non-capturing group or lookahead
-        match.input.slice(match.index - 3, 3).match(/\(\?[:=!]/) ||
+        nativ.test.call(/\(\?[:=!]/, match.input.slice(match.index - 3, 3)) ||
         // No need to separate tokens if before or after a `|`
         match.input[match.index - 1] === '|' ||
         match.input[match.index + match[0].length] === '|' ||

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -805,6 +805,16 @@ describe('XRegExp()', function() {
                 expect(XRegExp('(?:#\n.#\n)', 'x').source).toBe('(?:.)');
             });
 
+            it('should not add atom separator (?:) at the beginning or end of a lookahead in simple cases', function() {
+                expect(XRegExp('(?= . )', 'x').source).toBe('(?=.)');
+                expect(XRegExp('(?=#\n.#\n)', 'x').source).toBe('(?=.)');
+            });
+
+            it('should not add atom separator (?:) at the beginning or end of a negated lookahead in simple cases', function() {
+                expect(XRegExp('(?! . )', 'x').source).toBe('(?!.)');
+                expect(XRegExp('(?!#\n.#\n)', 'x').source).toBe('(?!.)');
+            });
+
             it('should not add atom separator (?:) at the beginning or end of the pattern in simple cases', function() {
                 expect(XRegExp(' ( . ) ', 'x').source).toBe('(.)');
                 expect(XRegExp(' (#\n.#\n) ', 'x').source).toBe('(.)');

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -800,6 +800,21 @@ describe('XRegExp()', function() {
                 expect(XRegExp('(#\n.#\n)', 'x').source).toBe('(.)');
             });
 
+            it('should not add atom separator (?:) at the beginning or end of non-capturing groups in simple cases', function() {
+                expect(XRegExp('(?: . )', 'x').source).toBe('(?:.)');
+                expect(XRegExp('(?:#\n.#\n)', 'x').source).toBe('(?:.)');
+            });
+
+            it('should not add atom separator (?:) at the beginning or end of the pattern in simple cases', function() {
+                expect(XRegExp(' ( . ) ', 'x').source).toBe('(.)');
+                expect(XRegExp(' (#\n.#\n) ', 'x').source).toBe('(.)');
+            });
+
+            it('should not add atom separator (?:) around | in simple cases', function() {
+                expect(XRegExp('( a | b )', 'x').source).toBe('(a|b)');
+                expect(XRegExp('(#\na#\n|#\nb#\n)', 'x').source).toBe('(a|b)');
+            });
+
             it('should allow whitespace between ( and ? for special groups', function() {
                 expect(XRegExp('( ?:)', 'x').source).toBe('(?:)');
                 expect(XRegExp('( ?=)', 'x').source).toBe('(?=)');

--- a/tests/spec/s-xregexp.js
+++ b/tests/spec/s-xregexp.js
@@ -803,6 +803,9 @@ describe('XRegExp()', function() {
             it('should not add atom separator (?:) at the beginning or end of non-capturing groups in simple cases', function() {
                 expect(XRegExp('(?: . )', 'x').source).toBe('(?:.)');
                 expect(XRegExp('(?:#\n.#\n)', 'x').source).toBe('(?:.)');
+
+                expect(XRegExp(' (?: . )', 'x').source).toBe('(?:.)');
+                expect(XRegExp(' (?:#\n.#\n)', 'x').source).toBe('(?:.)');
             });
 
             it('should not add atom separator (?:) at the beginning or end of a lookahead in simple cases', function() {


### PR DESCRIPTION
Following up on https://github.com/slevithan/xregexp/pull/164, this
change prevents a `(?:)` from being inserted in the following places:

* At the beginning of a non-capturing group or (negated) lookahead (the end is already handled)
* Before or after a `|`
* At the beginning or the end of the pattern

This solution isn't as complete as the one suggested in
https://github.com/slevithan/xregexp/issues/179, but it's a decent
stopgap.