### PR TITLE
[WIP] Add `namespacing` feature for named capture groups object

### DIFF
--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1403,12 +1403,17 @@ fixed.exec = function(str) {
         }
 
         // Attach named capture properties
+        let namedCaptureObject = match;
+        if (XRegExp.isInstalled('namespacing')) {
+            match.groups = Object.create(null); // https://tc39.github.io/proposal-regexp-named-groups/#sec-regexpbuiltinexec
+            namedCaptureObject = match.groups;
+        }
         if (this[REGEX_DATA] && this[REGEX_DATA].captureNames) {
             // Skip index 0
             for (let i = 1; i < match.length; ++i) {
                 const name = this[REGEX_DATA].captureNames[i - 1];
                 if (name) {
-                    match[name] = match[i];
+                    namedCaptureObject[name] = match[i];
                 }
             }
         }

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -19,7 +19,8 @@
 const REGEX_DATA = 'xregexp';
 // Optional features that can be installed and uninstalled
 const features = {
-    astral: false
+    astral: false,
+    namespacing: false
 };
 // Native methods to use and restore ('native' is an ES3 reserved keyword)
 const nativ = {
@@ -465,6 +466,17 @@ function runTokens(pattern, flags, pos, scope, context) {
  */
 function setAstral(on) {
     features.astral = on;
+}
+
+/**
+ * Enables or disables named capture groups. See here for details:
+ * https://github.com/tc39/proposal-regexp-named-groups
+ *
+ * @private
+ * @param {Boolean} on `true` to enable; `false` to disable.
+ */
+function setNamespacing(on) {
+    features.namespacing = on;
 }
 
 /**
@@ -916,17 +928,24 @@ XRegExp.globalize = (regex) => copyRegex(regex, {addG: true});
  * // With an options object
  * XRegExp.install({
  *   // Enables support for astral code points in Unicode addons (implicitly sets flag A)
- *   astral: true
+ *   astral: true,
+ *
+ *   // Enables named capture groups
+ *   namespacing: true
  * });
  *
  * // With an options string
- * XRegExp.install('astral');
+ * XRegExp.install('astral namespacing');
  */
 XRegExp.install = (options) => {
     options = prepareOptions(options);
 
     if (!features.astral && options.astral) {
         setAstral(true);
+    }
+
+    if (!features.namespacing && options.namespacing) {
+        setNamespacing(true);
     }
 };
 
@@ -936,6 +955,7 @@ XRegExp.install = (options) => {
  * @memberOf XRegExp
  * @param {String} feature Name of the feature to check. One of:
  *   - `astral`
+ *   - `namespacing`
  * @returns {Boolean} Whether the feature is installed.
  * @example
  *
@@ -1250,17 +1270,24 @@ XRegExp.test = (str, regex, pos, sticky) => !!XRegExp.exec(str, regex, pos, stic
  * // With an options object
  * XRegExp.uninstall({
  *   // Disables support for astral code points in Unicode addons
- *   astral: true
+ *   astral: true,
+ *
+ *   // Disables named capture groups
+ *   namespacing: true
  * });
  *
  * // With an options string
- * XRegExp.uninstall('astral');
+ * XRegExp.uninstall('astral namespacing');
  */
 XRegExp.uninstall = (options) => {
     options = prepareOptions(options);
 
     if (features.astral && options.astral) {
         setAstral(false);
+    }
+
+    if (features.namespacing && options.namespacing) {
+        setNamespacing(false);
     }
 };
 

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1403,17 +1403,17 @@ fixed.exec = function(str) {
         }
 
         // Attach named capture properties
-        let namedCaptureObject = match;
+        let groupsObject = match;
         if (XRegExp.isInstalled('namespacing')) {
             match.groups = Object.create(null); // https://tc39.github.io/proposal-regexp-named-groups/#sec-regexpbuiltinexec
-            namedCaptureObject = match.groups;
+            groupsObject = match.groups;
         }
         if (this[REGEX_DATA] && this[REGEX_DATA].captureNames) {
             // Skip index 0
             for (let i = 1; i < match.length; ++i) {
                 const name = this[REGEX_DATA].captureNames[i - 1];
                 if (name) {
-                    namedCaptureObject[name] = match[i];
+                    groupsObject[name] = match[i];
                 }
             }
         }
@@ -1503,22 +1503,22 @@ fixed.replace = function(search, replacement) {
         // functions isn't type-converted to a string
         result = nativ.replace.call(String(this), search, (...args) => {
             if (captureNames) {
-                let namedCaptureObject;
+                let groupsObject;
 
                 if (XRegExp.isInstalled('namespacing')) {
-                    namedCaptureObject = Object.create(null); // https://tc39.github.io/proposal-regexp-named-groups/#sec-regexpbuiltinexec
-                    args.push(namedCaptureObject);
+                    groupsObject = Object.create(null); // https://tc39.github.io/proposal-regexp-named-groups/#sec-regexpbuiltinexec
+                    args.push(groupsObject);
                 } else {
                     // Change the `args[0]` string primitive to a `String` object that can store
                     // properties. This really does need to use `String` as a constructor
                     args[0] = new String(args[0]);
-                    namedCaptureObject = args[0];
+                    groupsObject = args[0];
                 }
 
                 // Store named backreferences
                 for (let i = 0; i < captureNames.length; ++i) {
                     if (captureNames[i]) {
-                        namedCaptureObject[captureNames[i]] = args[i + 1];
+                        groupsObject[captureNames[i]] = args[i + 1];
                     }
                 }
             }

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1833,7 +1833,7 @@ XRegExp.addToken(
         if (!isNaN(match[1])) {
             throw new SyntaxError(`Cannot use integer as capture name ${match[0]}`);
         }
-        if (match[1] === 'length' || match[1] === '__proto__') {
+        if (!XRegExp.isInstalled('namespacing') && (match[1] === 'length' || match[1] === '__proto__')) {
             throw new SyntaxError(`Cannot use reserved word as capture name ${match[0]}`);
         }
         if (this.captureNames.includes(match[1])) {

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1503,13 +1503,22 @@ fixed.replace = function(search, replacement) {
         // functions isn't type-converted to a string
         result = nativ.replace.call(String(this), search, (...args) => {
             if (captureNames) {
-                // Change the `args[0]` string primitive to a `String` object that can store
-                // properties. This really does need to use `String` as a constructor
-                args[0] = new String(args[0]);
-                // Store named backreferences on the first argument
+                let namedCaptureObject;
+
+                if (XRegExp.isInstalled('namespacing')) {
+                    namedCaptureObject = Object.create(null); // https://tc39.github.io/proposal-regexp-named-groups/#sec-regexpbuiltinexec
+                    args.push(namedCaptureObject);
+                } else {
+                    // Change the `args[0]` string primitive to a `String` object that can store
+                    // properties. This really does need to use `String` as a constructor
+                    args[0] = new String(args[0]);
+                    namedCaptureObject = args[0];
+                }
+
+                // Store named backreferences
                 for (let i = 0; i < captureNames.length; ++i) {
                     if (captureNames[i]) {
-                        args[0][captureNames[i]] = args[i + 1];
+                        namedCaptureObject[captureNames[i]] = args[i + 1];
                     }
                 }
             }

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -469,7 +469,7 @@ function setAstral(on) {
 }
 
 /**
- * Enables or disables named capture groups. See here for details:
+ * Adds named capture groups to the `groups` property of match arrays. See here for details:
  * https://github.com/tc39/proposal-regexp-named-groups
  *
  * @private
@@ -930,7 +930,7 @@ XRegExp.globalize = (regex) => copyRegex(regex, {addG: true});
  *   // Enables support for astral code points in Unicode addons (implicitly sets flag A)
  *   astral: true,
  *
- *   // Enables named capture groups
+ *   // Adds named capture groups to the `groups` property of match arrays.
  *   namespacing: true
  * });
  *
@@ -1272,7 +1272,7 @@ XRegExp.test = (str, regex, pos, sticky) => !!XRegExp.exec(str, regex, pos, stic
  *   // Disables support for astral code points in Unicode addons
  *   astral: true,
  *
- *   // Disables named capture groups
+ *   // Don't add named capture groups to the `groups` property of match arrays.
  *   namespacing: true
  * });
  *

--- a/tests/helpers/h.js
+++ b/tests/helpers/h.js
@@ -6,7 +6,7 @@ if (typeof global === 'undefined') {
 
 // Ensure that all opt-in features are disabled when each spec starts
 global.disableOptInFeatures = function() {
-    XRegExp.uninstall('astral');
+    XRegExp.uninstall('namespacing astral');
 }
 
 // Repeat a string the specified number of times

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -450,6 +450,14 @@ describe('XRegExp.exec()', function() {
         expect(match[1]).toBe('a');
     });
 
+    it('should include named capture properties on the groups object if namespacing is installed', function() {
+        XRegExp.install('namespacing');
+        var match = XRegExp.exec('a', XRegExp('(?<name>a)'));
+
+        expect(match.groups.name).toBe('a');
+        expect(match[1]).toBe('a');
+    });
+
     it('should shaddow array prototype properties with named capture properties', function() {
         expect(XRegExp.exec('a', XRegExp('(?<concat>a)')).concat).toBe('a');
     });

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -1141,6 +1141,14 @@ describe('XRegExp.replace()', function() {
      * - Have no corresponding specs for String.prototype.replace.
      */
 
+    it('should pass the `groups` argument when `namespacing` is installed', function() {
+        XRegExp.install('namespacing')
+        var regex = XRegExp('(?s)(?<groupName>.)');
+        XRegExp.replace('test', regex, function (matched, capture1, position, S, groups) {
+            expect(groups).toEqual({groupName: 't'})
+        })
+    })
+
     it('should perform replace-all for string search with scope "all"', function() {
         expect(XRegExp.replace('test', 't', 'x', 'all')).toBe('xesx');
     });

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -802,9 +802,9 @@ describe('XRegExp.isInstalled()', function() {
     });
 
     it('should not check features using an options object', function() {
-        XRegExp.install('namespacing');
+        XRegExp.install('astral');
 
-        expect(XRegExp.isInstalled({namespacing: true})).toBe(false);
+        expect(XRegExp.isInstalled({astral: true})).toBe(false);
     });
 
     it('should report unknown features as not installed', function() {
@@ -812,9 +812,9 @@ describe('XRegExp.isInstalled()', function() {
     });
 
     it('should be case sensitive for feature names', function() {
-        XRegExp.install('namespacing');
+        XRegExp.install('astral');
 
-        expect(XRegExp.isInstalled('Namespacing')).toBe(false);
+        expect(XRegExp.isInstalled('Astral')).toBe(false);
     });
 
 });
@@ -1636,11 +1636,11 @@ describe('XRegExp.uninstall()', function() {
     });
 
     it('should undo repeated installations with a single uninstall', function() {
-        XRegExp.install('namespacing');
-        XRegExp.install('namespacing');
-        XRegExp.uninstall('namespacing');
+        XRegExp.install('astral');
+        XRegExp.install('astral');
+        XRegExp.uninstall('astral');
 
-        expect(XRegExp.isInstalled('namespacing')).toBe(false);
+        expect(XRegExp.isInstalled('astral')).toBe(false);
     });
 
     // TODO: Add basic specs that verify whether actual functionality of uninstalled features is

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -469,6 +469,14 @@ describe('XRegExp.exec()', function() {
         });
     });
 
+    it('should not throw an exception if reserved array properties are used as capture names if namespacing is installed', function() {
+        // Reserved names are 'length', '__proto__'
+        ['length', '__proto__'].forEach(function(name) {
+            XRegExp.install('namespacing');
+            expect(function() {XRegExp.exec('a', XRegExp('(?<' + name + '>a)'));}).not.toThrowError(SyntaxError);
+        });
+    });
+
     it('should allow reserved JavaScript keywords as capture names', function() {
         ['eval', 'for', 'function', 'if', 'throw'].forEach(function(keyword) {
             expect(XRegExp.exec('a', XRegExp('(?<' + keyword + '>a)'))[keyword]).toBe('a');

--- a/tests/spec/s-xregexp-methods.js
+++ b/tests/spec/s-xregexp-methods.js
@@ -728,10 +728,11 @@ describe('XRegExp.install()', function() {
 
     // NOTE: All optional features are uninstalled before each spec runs
 
-    var features = ['astral'];
+    var features = ['namespacing', 'astral'];
 
     it('should install all features set as true on an options object', function() {
         XRegExp.install({
+            namespacing: true,
             astral: true
         });
 
@@ -742,6 +743,7 @@ describe('XRegExp.install()', function() {
 
     it('should not install features set as false on an options object', function() {
         XRegExp.install({
+            namespacing: false,
             astral: false
         });
 
@@ -751,7 +753,7 @@ describe('XRegExp.install()', function() {
     });
 
     it('should install all features in a space-delimited options string', function() {
-        XRegExp.install('astral astral');
+        XRegExp.install('namespacing astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(true);
@@ -759,7 +761,7 @@ describe('XRegExp.install()', function() {
     });
 
     it('should install all features in a comma-delimited options string', function() {
-        XRegExp.install('astral,astral');
+        XRegExp.install('namespacing,astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(true);
@@ -767,7 +769,7 @@ describe('XRegExp.install()', function() {
     });
 
     it('should install all features in a comma+space-delimited options string', function() {
-        XRegExp.install('astral, astral');
+        XRegExp.install('namespacing, astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(true);
@@ -782,27 +784,27 @@ describe('XRegExp.install()', function() {
 describe('XRegExp.isInstalled()', function() {
 
     it('should not check multiple space-delimited features simultaneously', function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing astral');
 
-        expect(XRegExp.isInstalled('astral astral')).toBe(false);
+        expect(XRegExp.isInstalled('namespacing astral')).toBe(false);
     });
 
     it('should not check multiple comma-delimited features simultaneously', function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing astral');
 
-        expect(XRegExp.isInstalled('astral,astral')).toBe(false);
+        expect(XRegExp.isInstalled('namespacing,astral')).toBe(false);
     });
 
     it('should not check multiple comma+space-delimited features simultaneously', function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing astral');
 
-        expect(XRegExp.isInstalled('astral, astral')).toBe(false);
+        expect(XRegExp.isInstalled('namespacing, astral')).toBe(false);
     });
 
     it('should not check features using an options object', function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing');
 
-        expect(XRegExp.isInstalled({astral: true})).toBe(false);
+        expect(XRegExp.isInstalled({namespacing: true})).toBe(false);
     });
 
     it('should report unknown features as not installed', function() {
@@ -810,9 +812,9 @@ describe('XRegExp.isInstalled()', function() {
     });
 
     it('should be case sensitive for feature names', function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing');
 
-        expect(XRegExp.isInstalled('Astral')).toBe(false);
+        expect(XRegExp.isInstalled('Namespacing')).toBe(false);
     });
 
 });
@@ -1582,13 +1584,14 @@ describe('XRegExp.test()', function() {
 describe('XRegExp.uninstall()', function() {
 
     beforeEach(function() {
-        XRegExp.install('astral');
+        XRegExp.install('namespacing astral');
     });
 
-    var features = ['astral'];
+    var features = ['namespacing', 'astral'];
 
     it('should uninstall all features set as true on an options object', function() {
         XRegExp.uninstall({
+            namespacing: true,
             astral: true
         });
 
@@ -1599,6 +1602,7 @@ describe('XRegExp.uninstall()', function() {
 
     it('should not uninstall features set as false on an options object', function() {
         XRegExp.uninstall({
+            namespacing: false,
             astral: false
         });
 
@@ -1608,7 +1612,7 @@ describe('XRegExp.uninstall()', function() {
     });
 
     it('should uninstall all features in a space-delimited options string', function() {
-        XRegExp.uninstall('astral astral');
+        XRegExp.uninstall('namespacing astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(false);
@@ -1616,7 +1620,7 @@ describe('XRegExp.uninstall()', function() {
     });
 
     it('should uninstall all features in a comma-delimited options string', function() {
-        XRegExp.uninstall('astral,astral');
+        XRegExp.uninstall('namespacing,astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(false);
@@ -1624,7 +1628,7 @@ describe('XRegExp.uninstall()', function() {
     });
 
     it('should uninstall all features in a comma+space-delimited options string', function() {
-        XRegExp.uninstall('astral, astral');
+        XRegExp.uninstall('namespacing, astral');
 
         features.forEach(function(feature) {
             expect(XRegExp.isInstalled(feature)).toBe(false);
@@ -1632,11 +1636,11 @@ describe('XRegExp.uninstall()', function() {
     });
 
     it('should undo repeated installations with a single uninstall', function() {
-        XRegExp.install('astral');
-        XRegExp.install('astral');
-        XRegExp.uninstall('astral');
+        XRegExp.install('namespacing');
+        XRegExp.install('namespacing');
+        XRegExp.uninstall('namespacing');
 
-        expect(XRegExp.isInstalled('astral')).toBe(false);
+        expect(XRegExp.isInstalled('namespacing')).toBe(false);
     });
 
     // TODO: Add basic specs that verify whether actual functionality of uninstalled features is


### PR DESCRIPTION
This addresses https://github.com/slevithan/xregexp/issues/175

I still need to add proper tests, but the new behavior can be
demonstrated by running this after `npm run build`

```js
var XRegExp = require('./')
XRegExp.install('namespacing')
var regex = XRegExp('(?s)(?<__proto__>.)');
var match = XRegExp.exec('test', regex);
console.log(match)

const replaced = XRegExp.replace('test', regex, function (matched, capture1, position, S, groups) {
    console.log({groups})
})
```