### PR TITLE
tests: Remove unused `repeat()` helper

### DIFF
--- a/tests/helpers/h.js
+++ b/tests/helpers/h.js
@@ -9,11 +9,6 @@ global.disableOptInFeatures = function() {
     XRegExp.uninstall('astral');
 }
 
-// Repeat a string the specified number of times
-global.repeat = function (str, num) {
-    return Array(num + 1).join(str);
-}
-
 // Property name used for extended regex instance data
 global.REGEX_DATA = 'xregexp';
 


### PR DESCRIPTION
This fell out of use in 8e6244cd215f251ba6589ea5324f0a667698e8f2,
but it wasn't removed there.