### PR TITLE
Add `module` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "unicode"
   ],
   "main": "./lib",
+  "module": "./src/index.js",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
I think you want this in `package.json` for the sake of tools like Rollup optimizing builds.

See https://stackoverflow.com/a/42817320/271577