### PR TITLE
ESLint: Enforce object destructuring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,7 +249,7 @@ module.exports = {
             "error",
             {
                 "array": false,
-                "object": false
+                "object": true
             }
         ],
         "prefer-numeric-literals": "error",

--- a/src/addons/matchrecursive.js
+++ b/src/addons/matchrecursive.js
@@ -77,7 +77,7 @@ export default (XRegExp) => {
         const sticky = flags.includes('y');
         // Flag `y` is controlled internally
         const basicFlags = flags.replace(/y/g, '');
-        let escapeChar = options.escapeChar;
+        let {escapeChar} = options;
         const vN = options.valueNames;
         const output = [];
         let openTokens = 0;

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -55,7 +55,7 @@ const correctExecNpcg = nativ.exec.call(/()??/, '')[1] === undefined;
 // Check for ES6 `flags` prop support
 const hasFlagsProp = /x/.flags !== undefined;
 // Shortcut to `Object.prototype.toString`
-const toString = {}.toString;
+const {toString} = {};
 
 function hasNativeFlag(flag) {
     // Can't check based on the presence of properties/getters since browsers might support such
@@ -1501,7 +1501,7 @@ fixed.replace = function(search, replacement) {
 
     if (isRegex) {
         if (search[REGEX_DATA]) {
-            captureNames = search[REGEX_DATA].captureNames;
+            ({captureNames} = search[REGEX_DATA]);
         }
         // Only needed if `search` is nonglobal
         origLastIndex = search.lastIndex;


### PR DESCRIPTION
This is a follow-up to https://github.com/slevithan/xregexp/pull/236
We could also do array destructuring, but it looked a little
weird to me, so I left it out for now.

EDIT: Enforcing array destructuring also touches files in `tools/`, and I'm not sure if we have a reason not to do that. See https://github.com/slevithan/xregexp/pull/236#issuecomment-382510746