### PR TITLE
Pin Travis to Node v9 to avoid v10 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - 9
 script:
   - npm test
   - '[ -z "$SAUCE_USERNAME" ] || [ -z "$SAUCE_ACCESS_KEY" ] || npm run test-saucelabs'


### PR DESCRIPTION
v10 fails currently: https://travis-ci.org/slevithan/xregexp/builds/370310563#L510-L528

```
Failures:
1) XRegExp() supports new regex syntax: named capture should throw an exception if characters other than A-Z, a-z, 0-9, $, and _ are used in capture names
  Message:
    Expected function to throw an Error.
  Stack:
    Error: Expected function to throw an Error.
        at UserContext.<anonymous> (/home/travis/build/slevithan/xregexp/tests/spec/s-xregexp.js:407:61)
  Message:
    Expected function to throw an Error.
  Stack:
    Error: Expected function to throw an Error.
        at UserContext.<anonymous> (/home/travis/build/slevithan/xregexp/tests/spec/s-xregexp.js:408:63)
  Message:
    Expected function to throw an Error.
  Stack:
    Error: Expected function to throw an Error.
        at UserContext.<anonymous> (/home/travis/build/slevithan/xregexp/tests/spec/s-xregexp.js:409:59)

398 specs, 1 failure
```

See also https://github.com/slevithan/xregexp/pull/241#issuecomment-384480732