### PR TITLE
Add `module` to package.json for rollup/webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "regular expression",
     "unicode"
   ],
-  "main": "./lib",
+  "main": "./lib/index.js",
+  "module": "./src/index.js",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
This will allow users to consume the original esm modern code. This would make #275 a minor non-blocking issue. :)