### PR TITLE
Add browser field to package.json to fix webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "regular expression",
     "unicode"
   ],
+  "browser": "./lib/index.js",
   "main": "./lib/index.js",
   "module": "./src/index.js",
   "files": [


### PR DESCRIPTION
This should close https://github.com/slevithan/xregexp/issues/305, see https://github.com/slevithan/xregexp/issues/305#issuecomment-740353997:

> Actually, after reading https://webpack.js.org/configuration/resolve/#resolvemainfields more closely, it sounds like adding a `browser` field to `package.json`, that points to `lib/index.js` (same as `main`) should fix things.
>
> > resolve.mainFields
> > [string]
> >
> > When importing from an npm package, e.g. import * as D3 from 'd3', this option will determine which fields in its package.json are checked. The default values will vary based upon the target specified in your webpack configuration.
> >
> > When the target property is set to webworker, web, or left unspecified:
> >
> > webpack.config.js
> >
> > module.exports = {
> >   //...
> >   resolve: {
> >     mainFields: ['browser', 'module', 'main']
> >   }
> > };
> > For any other target (including node):
> >
> > webpack.config.js
> >
> > module.exports = {
> >   //...
> >   resolve: {
> >     mainFields: ['module', 'main']
> >   }
> > };
> > For example, consider an arbitrary library called upstream with a package.json that contains the following fields:
> >
> > {
> >   "browser": "build/upstream.js",
> >   "module": "index"
> > }
> > When we import * as Upstream from 'upstream' this will actually resolve to the file in the browser property. The browser property takes precedence because it's the first item in mainFields. Meanwhile, a Node.js application bundled by webpack will first try to resolve using the file in the module field.
>
> I'll open a PR for that.