### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+    - run: npm install
+    - run: npm test
+    - shell: bash
+      env:
+        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      run: '[ -z "$SAUCE_USERNAME" ] || [ -z "$SAUCE_ACCESS_KEY" ] || npm run test-saucelabs'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v1
+    - run: npm install -g npm@7
     - run: npm install
     - run: npm test
     - shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v1
-    - run: npm install -g npm@7
+      with:
+        node-version: '15'
     - run: npm install
     - run: npm test
     - shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - node
-script:
-  - npm test
-  - '[ -z "$SAUCE_USERNAME" ] || [ -z "$SAUCE_ACCESS_KEY" ] || npm run test-saucelabs'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XRegExp 4.4.0
 
-[![Build Status](https://travis-ci.org/slevithan/xregexp.svg?branch=master)](https://travis-ci.org/slevithan/xregexp)
+[![Build Status](https://github.com/slevithan/xregexp/workflows/.github/workflows/build.yml/badge.svg)](https://github.com/slevithan/xregexp/actions)
 
 XRegExp provides augmented (and extensible) JavaScript regular expressions. You get modern syntax and flags beyond what browsers support natively. XRegExp is also a regex utility belt with tools to make your grepping and parsing easier, while freeing you from regex cross-browser inconsistencies and other annoyances.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "xregexp",
-  "version": "4.4.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.4.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.1"
@@ -24,7 +24,6 @@
         "eslint": "^7.12.1",
         "jasmine": "^3.6.2",
         "jsesc": "^3.0.1",
-        "typescript": "^3.8.0-dev.20200211",
         "unicode-property-value-aliases": "^3.5.0",
         "zuul": "^3.12.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "xregexp",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.1"
@@ -24,6 +24,7 @@
         "eslint": "^7.12.1",
         "jasmine": "^3.6.2",
         "jsesc": "^3.0.1",
+        "typescript": "^3.8.0-dev.20200211",
         "unicode-property-value-aliases": "^3.5.0",
         "zuul": "^3.12.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "xregexp",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint": "^7.12.1",
     "jasmine": "^3.6.2",
     "jsesc": "^3.0.1",
-    "typescript": "^3.8.0-dev.20200211",
     "unicode-property-value-aliases": "^3.5.0",
     "zuul": "^3.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint": "^7.12.1",
     "jasmine": "^3.6.2",
     "jsesc": "^3.0.1",
+    "typescript": "^3.8.0-dev.20200211",
     "unicode-property-value-aliases": "^3.5.0",
     "zuul": "^3.12.0"
   },


### PR DESCRIPTION
Travis CI is no longer providing CI minutes for open source projects: https://news.ycombinator.com/item?id=25338983

It's also been pretty slow: the build for https://github.com/slevithan/xregexp/pull/308
hasn't started in 13 minutes

The config file is based on the template at https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs#specifying-the-nodejs-version