### PR TITLE
Bump version to 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XRegExp 4.4.0
+# XRegExp 4.4.1
 
 [![Build Status](https://github.com/slevithan/xregexp/workflows/Node.js%20CI/badge.svg)](https://github.com/slevithan/xregexp/actions)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "xregexp",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xregexp",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Extended regular expressions",
   "homepage": "http://xregexp.com/",
   "author": "Steven Levithan <steves_list@hotmail.com>",

--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp.build 4.4.0
+ * XRegExp.build 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2012-present MIT License
  */

--- a/src/addons/matchrecursive.js
+++ b/src/addons/matchrecursive.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp.matchRecursive 4.4.0
+ * XRegExp.matchRecursive 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2009-present MIT License
  */

--- a/src/addons/unicode-base.js
+++ b/src/addons/unicode-base.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Base 4.4.0
+ * XRegExp Unicode Base 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2008-present MIT License
  */

--- a/src/addons/unicode-blocks.js
+++ b/src/addons/unicode-blocks.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Blocks 4.4.0
+ * XRegExp Unicode Blocks 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2010-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/addons/unicode-categories.js
+++ b/src/addons/unicode-categories.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Categories 4.4.0
+ * XRegExp Unicode Categories 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2010-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/addons/unicode-properties.js
+++ b/src/addons/unicode-properties.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Properties 4.4.0
+ * XRegExp Unicode Properties 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2012-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/addons/unicode-scripts.js
+++ b/src/addons/unicode-scripts.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Scripts 4.4.0
+ * XRegExp Unicode Scripts 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2010-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp 4.4.0
+ * XRegExp 4.4.1
  * <xregexp.com>
  * Steven Levithan (c) 2007-present MIT License
  */
@@ -659,7 +659,7 @@ XRegExp.prototype = new RegExp();
  * @memberOf XRegExp
  * @type String
  */
-XRegExp.version = '4.4.0';
+XRegExp.version = '4.4.1';
 
 // ==--------------------------==
 // Public methods


### PR DESCRIPTION
Changes include:

~* Remove no longer relevant lastIndex code from replace method, fixes https://github.com/slevithan/xregexp/issues/287~
* Add browser field to package.json to fix webpack: https://github.com/slevithan/xregexp/pull/308

To generate this commit, I adapted the steps at https://github.com/slevithan/xregexp/pull/205#issuecomment-354236652

Here's a fuller list of changes that can be needed with new releases:

> * Version number
>   * Update version number and year in headers, config files, README.
>   * Update year in LICENSE.
>   * Update version number in `XRegExp.version`.
> * Publish
>   * Publish new git tag. E.g.:
>     * `git tag -a v3.1.0 -m "Release 3.1.0"`.
>     * `git push origin v3.1.0`.
>   * `npm publish`.

(closes https://github.com/slevithan/xregexp/pull/311)