### PR TITLE
Bump version to 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XRegExp 4.4.1-next
+# XRegExp 5.0.0-next
 
 [![Build Status](https://github.com/slevithan/xregexp/workflows/Node.js%20CI/badge.svg)](https://github.com/slevithan/xregexp/actions)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "xregexp",
-  "version": "4.4.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.4.1",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xregexp",
-  "version": "4.4.1",
+  "version": "5.0.0",
   "description": "Extended regular expressions",
   "homepage": "http://xregexp.com/",
   "author": "Steven Levithan <steves_list@hotmail.com>",

--- a/src/addons/build.js
+++ b/src/addons/build.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp.build 4.4.1
+ * XRegExp.build 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2012-present MIT License
  */

--- a/src/addons/matchrecursive.js
+++ b/src/addons/matchrecursive.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp.matchRecursive 4.4.1
+ * XRegExp.matchRecursive 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2009-present MIT License
  */

--- a/src/addons/unicode-base.js
+++ b/src/addons/unicode-base.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Base 4.4.1
+ * XRegExp Unicode Base 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2008-present MIT License
  */

--- a/src/addons/unicode-categories.js
+++ b/src/addons/unicode-categories.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Categories 4.4.1
+ * XRegExp Unicode Categories 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2010-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/addons/unicode-properties.js
+++ b/src/addons/unicode-properties.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Properties 4.4.1
+ * XRegExp Unicode Properties 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2012-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/addons/unicode-scripts.js
+++ b/src/addons/unicode-scripts.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp Unicode Scripts 4.4.1
+ * XRegExp Unicode Scripts 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2010-present MIT License
  * Unicode data by Mathias Bynens <mathiasbynens.be>

--- a/src/xregexp.js
+++ b/src/xregexp.js
@@ -1,5 +1,5 @@
 /*!
- * XRegExp 4.4.1
+ * XRegExp 5.0.0
  * <xregexp.com>
  * Steven Levithan (c) 2007-present MIT License
  */
@@ -646,7 +646,7 @@ XRegExp.prototype = new RegExp();
  * @memberOf XRegExp
  * @type String
  */
-XRegExp.version = '4.4.1';
+XRegExp.version = '5.0.0';
 
 // ==--------------------------==
 // Public methods


### PR DESCRIPTION
Changes include:

* BREAKING: Handle ES2018 capture names: https://github.com/slevithan/xregexp/pull/247
* BREAKING: Enable `namespacing` feature by default: https://github.com/slevithan/xregexp/pull/316
* BREAKING: Remove Unicode Blocks addon: https://github.com/slevithan/xregexp/commit/4860122362c9822f35ab7f2deea7973a5815fcac
* restore perf tweak that made a meaningful difference in regex construction perf tests: https://github.com/slevithan/xregexp/commit/5f182615a4d9e02e6c297e21ce51eda816494f77
* XRegExp.exec: preserve groups obj that comes from native ES2018 named capture: https://github.com/slevithan/xregexp/commit/c4a83e76fc3e1ab5a9053618267dff33edd1174e
* Make XRegExp.exec set groups prop to undefined if there are no named captures (closes #320): https://github.com/slevithan/xregexp/commit/7fea4762ef321452cb9aa1449b39f54036e1d28d
* Support optional 'Script=' prefix (from ES2018 syntax) for Unicode script tokens (#225): https://github.com/slevithan/xregexp/commit/bb35ead3ad1c57b27eb4c1b3a94e5ed9ecc9a09c
* XRegExp.matchRecursive: Add delimiter and pos info when unbalanced delimiters are found (closes #293): https://github.com/slevithan/xregexp/commit/9660b90db044cf5c2ffa5c297f7696e1dbfc531e
* XRegExp.escape: Escape whitespace in a way that works with ES6 flag u (fixes #197): https://github.com/slevithan/xregexp/commit/e22a52b7f035551f47eaa2b72fc92dfc777fb87d

To generate this commit, I adapted the steps at https://github.com/slevithan/xregexp/pull/205#issuecomment-354236652

Here's a fuller list of changes that can be needed with new releases:

> * Version number
>   * Update version number and year in headers, config files, README.
>   * Update version number in `XRegExp.version`.
> * Publish
>   * Publish new git tag. E.g.:
>     * `git tag -a v3.1.0 -m "Release 3.1.0"`.
>     * `git push origin v3.1.0`.
>   * `npm publish`.