### PR TITLE
Fixing typeerror from 312a1e6

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -347,7 +347,7 @@ declare namespace XRegExp {
          * - "skip" - treats the unbalanced delimiter as raw text, skipping one delimiter at a time.
          * - "skip-lazy" - treats the unbalanced delimiter as raw text, skipping one character at a time.
          */
-        unbalancedDelimiters: 'error' | 'skip' | 'skip-lazy';
+        unbalancedDelimiters?: 'error' | 'skip' | 'skip-lazy';
     }
 
     /**


### PR DESCRIPTION
Saw this build error: https://github.com/slevithan/xregexp/runs/3231325861

Whoops, sorry about that!